### PR TITLE
Add clipboard integration and polish session list UI

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,3 +27,4 @@ cpal = "0.15"
 hound = "3.5"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
+arboard = "3.3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,24 @@ fn load_config() -> Result<WhisperConfig, String> {
     recording::load_config()
 }
 
+#[tauri::command]
+fn copy_transcript_to_clipboard(session_id: String) -> Result<(), String> {
+    // Load sessions
+    let index = recording::load_sessions()?;
+
+    // Find session by ID
+    let session = index.sessions.iter()
+        .find(|s| s.id == session_id)
+        .ok_or("Session not found")?;
+
+    // Copy transcript to clipboard
+    if session.transcript.is_empty() {
+        return Err("No transcript available for this session".to_string());
+    }
+
+    recording::copy_to_clipboard(&session.transcript)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   let app_state = AppState {
@@ -74,7 +92,8 @@ pub fn run() {
         stop_recording,
         get_sessions,
         get_recording_duration,
-        load_config
+        load_config,
+        copy_transcript_to_clipboard
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,24 +56,28 @@ function App() {
     try {
       await invoke("start_recording");
       setIsRecording(true);
-      setStatus("Recording...");
+      setStatus("⏺️ Recording...");
     } catch (error) {
       console.error("Failed to start recording:", error);
-      setStatus(`Error: ${error}`);
+      setStatus(`❌ Error: ${error}`);
     }
   };
 
   const handleStopRecording = async () => {
     try {
-      setStatus("Saving and transcribing audio...");
+      setStatus("🔄 Saving and transcribing audio...");
       const newSession = await invoke<Session>("stop_recording");
       setIsRecording(false);
 
-      // Check if transcription succeeded
+      // Check transcription and clipboard status
       if (newSession.transcript && newSession.transcript.length > 0) {
-        setStatus("Transcription complete!");
+        if (newSession.clipboard_copied) {
+          setStatus("✅ Transcript copied to clipboard!");
+        } else {
+          setStatus("⚠️ Transcription complete (clipboard copy failed - use Copy button)");
+        }
       } else {
-        setStatus("Recording saved (transcription failed)");
+        setStatus("⚠️ Recording saved (transcription failed - check Whisper setup)");
       }
 
       // Reload sessions to include the new one
@@ -82,11 +86,11 @@ function App() {
       // Select the new session
       setSelectedId(newSession.id);
 
-      // Reset status after a moment
-      setTimeout(() => setStatus("Ready to record"), 3000);
+      // Reset status after 5 seconds
+      setTimeout(() => setStatus("Ready to record"), 5000);
     } catch (error) {
       console.error("Failed to stop recording:", error);
-      setStatus(`Error: ${error}`);
+      setStatus(`❌ Error: ${error}`);
       setIsRecording(false);
     }
   };

--- a/src/components/MainPanel.css
+++ b/src/components/MainPanel.css
@@ -69,11 +69,36 @@
   font-family: monospace;
 }
 
-.status-text {
-  margin-top: 15px;
+.copy-button {
+  margin: 16px 0;
+  padding: 10px 20px;
+  background-color: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 6px;
   font-size: 14px;
-  color: #666;
-  font-style: italic;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.copy-button:hover {
+  background-color: #357abd;
+}
+
+.copy-button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.status-bar {
+  padding: 12px 30px;
+  background-color: #f5f5f5;
+  border-top: 1px solid #ddd;
+}
+
+.status-text {
+  font-size: 14px;
+  color: #333;
 }
 
 .session-details {

--- a/src/components/SessionList.css
+++ b/src/components/SessionList.css
@@ -8,7 +8,7 @@
   overflow: hidden;
 }
 
-.session-list-header {
+.session-list h2 {
   margin: 0;
   padding: 20px;
   font-size: 18px;
@@ -17,14 +17,23 @@
   border-bottom: 1px solid #ddd;
 }
 
-.session-items {
+.sessions {
   flex: 1;
   overflow-y: auto;
 }
 
+.no-sessions {
+  padding: 20px;
+  text-align: center;
+  color: #999;
+  font-style: italic;
+}
+
 .session-item {
-  padding: 15px 20px;
-  border-bottom: 1px solid #e0e0e0;
+  padding: 12px;
+  margin: 8px;
+  background-color: #f9f9f9;
+  border-radius: 6px;
   cursor: pointer;
   transition: background-color 0.2s;
 }
@@ -34,20 +43,34 @@
 }
 
 .session-item.selected {
-  background-color: #d0e8ff;
-  border-left: 3px solid #0066cc;
+  background-color: #e3f2fd;
+  border: 1px solid #2196f3;
+}
+
+.session-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #555;
+  margin-bottom: 6px;
+}
+
+.session-icon {
+  font-size: 16px;
 }
 
 .session-timestamp {
+  font-weight: 500;
+}
+
+.session-duration {
+  color: #888;
   font-size: 12px;
-  color: #666;
-  margin-bottom: 5px;
 }
 
 .session-preview {
-  font-size: 14px;
-  color: #333;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 13px;
+  color: #666;
+  line-height: 1.4;
 }

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -7,6 +7,27 @@ interface SessionListProps {
   onSelectSession: (id: string) => void;
 }
 
+function formatShortTimestamp(timestamp: string): string {
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+  } catch {
+    return timestamp;
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins}:${secs.toString().padStart(2, "0")}`;
+}
+
 export default function SessionList({
   sessions,
   selectedId,
@@ -14,20 +35,35 @@ export default function SessionList({
 }: SessionListProps) {
   return (
     <div className="session-list">
-      <h2 className="session-list-header">Sessions</h2>
-      <div className="session-items">
-        {sessions.map((session) => (
-          <div
-            key={session.id}
-            className={`session-item ${
-              selectedId === session.id ? "selected" : ""
-            }`}
-            onClick={() => onSelectSession(session.id)}
-          >
-            <div className="session-timestamp">{session.timestamp}</div>
-            <div className="session-preview">{session.preview}</div>
-          </div>
-        ))}
+      <h2>Sessions</h2>
+      <div className="sessions">
+        {sessions.length === 0 ? (
+          <div className="no-sessions">No recordings yet</div>
+        ) : (
+          sessions.map((session) => (
+            <div
+              key={session.id}
+              className={`session-item ${
+                session.id === selectedId ? "selected" : ""
+              }`}
+              onClick={() => onSelectSession(session.id)}
+            >
+              <div className="session-header">
+                <span className="session-icon">🎙️</span>
+                <span className="session-timestamp">
+                  {formatShortTimestamp(session.timestamp)}
+                </span>
+                <span className="session-duration">
+                  ({formatDuration(session.duration)})
+                </span>
+              </div>
+              <div className="session-preview">
+                {session.preview.substring(0, 50)}
+                {session.preview.length > 50 && "..."}
+              </div>
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface Session {
   duration: number;
   transcript_path?: string;
   transcript?: string;
+  clipboard_copied?: boolean;
 }
 
 export interface SessionIndex {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   clearScreen: false,
   server: {
-    port: 5173,
+    port: 3001,
     strictPort: true,
   },
   envPrefix: ["VITE_", "TAURI_"],


### PR DESCRIPTION
## Summary

Transcripts now automatically copy to the clipboard after recording completes, eliminating the need to manually open transcript files. The UI has been polished with clearer timestamps, better visual feedback through emoji indicators, and a more compact session list that shows recording durations at a glance. Users can also manually copy any transcript using the new copy button.

## Technical Details

- Added arboard crate for cross-platform clipboard access
- Implemented automatic clipboard copy in transcription pipeline with `clipboard_copied` field tracking
- Created manual copy command (`copy_transcript_to_clipboard`) accessible via UI button
- Enhanced error messages to be user-friendly (e.g., "Whisper.cpp is not set up" instead of raw path errors)
- Improved date/time formatting using localized formats (e.g., "January 15, 2024, 3:45 PM")
- Added emoji status indicators (⏺️ recording, ✅ success, ❌ error, ⚠️ warning, 🔄 processing)
- Redesigned session list with microphone icons, compact timestamps, and visible durations
- Moved status to dedicated bottom bar for better visual hierarchy
- Changed Vite dev server port from 5173 to 3001
