### PR TITLE
IMPROVE: Add audio compression pipeline with settings panel and batch worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@tauri-apps/api": "^2.9.0",
         "@tauri-apps/cli": "^2.9.2",
+        "@tauri-apps/plugin-dialog": "^2.4.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1714,9 +1715,9 @@
       "license": "MIT"
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz",
-      "integrity": "sha512-qD5tMjh7utwBk9/5PrTA/aGr3i5QaJ/Mlt7p8NilQ45WgbifUNPyKWsA63iQ8YfQq6R8ajMapU+/Q8nMcPRLNw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1926,6 +1927,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.9.0",
     "@tauri-apps/cli": "^2.9.2",
+    "@tauri-apps/plugin-dialog": "^2.4.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.9.2", features = [] }
 tauri-plugin-log = "2"
+tauri-plugin-dialog = "2"
 cpal = "0.15"
 hound = "3.5"
 chrono = { version = "0.4", features = ["serde"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   ],
   "permissions": [
     "core:default",
-    "core:window:allow-set-title"
+    "core:window:allow-set-title",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -1,0 +1,41 @@
+//! Native window menu bar.
+//!
+//! On Windows/Linux the menu sits at the top of the app window; on macOS it
+//! appears in the global menu bar. Top-level entries must be submenus (it's
+//! not possible to put a "leaf" item directly at the top level on any of
+//! Tauri's target platforms), so we group items under a single "App" submenu
+//! that future entries (About, Check for updates, …) can drop into.
+
+use tauri::menu::{Menu, MenuEvent, MenuItem, Submenu};
+use tauri::{AppHandle, Emitter, Runtime};
+
+/// Tauri event name fired when the user picks the Settings menu item.
+/// The frontend listens for it and opens the Settings panel.
+pub const MENU_OPEN_SETTINGS_EVENT: &str = "menu-open-settings";
+
+const SETTINGS_ITEM_ID: &str = "menu-settings";
+
+/// Build the application menu and attach it to the given app handle.
+pub fn build_app_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<Menu<R>> {
+    // No keyboard accelerator: muda 0.17 (Tauri 2.9's menu lib) does not
+    // reliably bind punctuation-key accelerators (e.g., Ctrl+Comma) for menu
+    // items nested under a Submenu on Windows. The hint string would display
+    // in the menu but the key combination wouldn't fire — worse than not
+    // showing one at all. Mouse + Alt-navigation still reach the item.
+    let settings_item = MenuItem::with_id(app, SETTINGS_ITEM_ID, "Settings…", true, None::<&str>)?;
+
+    let app_submenu = Submenu::with_items(app, "ThoughtCast", true, &[&settings_item])?;
+    let menu = Menu::with_items(app, &[&app_submenu])?;
+    Ok(menu)
+}
+
+/// Handle a menu click event by routing the known IDs to Tauri events the
+/// frontend listens for. Unknown IDs are ignored.
+pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: MenuEvent) {
+    match event.id().as_ref() {
+        SETTINGS_ITEM_ID => {
+            let _ = app.emit(MENU_OPEN_SETTINGS_EVENT, ());
+        }
+        _ => {}
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,15 +1,34 @@
+mod app_menu;
 mod recording;
 
 use recording::{
-    estimate_transcription_time, extract_transcription_stats, RecordingState, RecordingStatus,
-    Session, SessionIndex, SharedRecordingState, TranscriptionCompleteEvent,
-    TranscriptionErrorEvent, TranscriptionEstimate, TranscriptionResult, WhisperConfig,
+    estimate_transcription_time, extract_transcription_stats, new_shared_progress,
+    request_cancel_batch, AppConfig, BatchCompleteEvent, BatchEventEmitter, BatchProgress,
+    BatchProgressEvent, PathKind, PathValidation, RecordingState, RecordingStatus, Session,
+    SessionIndex, SharedBatchProgress, SharedRecordingState, StorageStats,
+    TranscriptionCompleteEvent, TranscriptionErrorEvent, TranscriptionEstimate,
+    TranscriptionResult,
 };
 use std::sync::{Arc, Mutex};
-use tauri::{Emitter, State};
+use tauri::{Emitter, Manager, State};
 
 struct AppState {
     recording: SharedRecordingState,
+    batch_progress: SharedBatchProgress,
+}
+
+/// Adapter that bridges the batch worker's emitter trait to Tauri's event bus.
+struct TauriBatchEmitter {
+    app: tauri::AppHandle,
+}
+
+impl BatchEventEmitter for TauriBatchEmitter {
+    fn emit_progress(&self, event: BatchProgressEvent) {
+        let _ = self.app.emit("compression-batch-progress", event);
+    }
+    fn emit_complete(&self, event: BatchCompleteEvent) {
+        let _ = self.app.emit("compression-batch-complete", event);
+    }
 }
 
 #[tauri::command]
@@ -60,6 +79,9 @@ fn stop_recording(state: State<AppState>, app: tauri::AppHandle) -> Result<Sessi
                         session: updated_session,
                     },
                 );
+            }
+            TranscriptionResult::Compressed(compression_event) => {
+                let _ = app.emit("session-audio-compressed", compression_event);
             }
             TranscriptionResult::Error { session_id, error } => {
                 let _ = app.emit(
@@ -128,8 +150,18 @@ fn get_audio_levels(state: State<AppState>) -> Result<Vec<f32>, String> {
 }
 
 #[tauri::command]
-fn load_config() -> Result<WhisperConfig, String> {
+fn load_config() -> Result<AppConfig, String> {
     recording::load_config()
+}
+
+#[tauri::command]
+fn save_config(config: AppConfig) -> Result<(), String> {
+    recording::save_config(&config)
+}
+
+#[tauri::command]
+fn validate_config_path(path: String, kind: PathKind) -> Result<PathValidation, String> {
+    Ok(recording::validate_path(&path, kind))
 }
 
 #[tauri::command]
@@ -168,14 +200,50 @@ fn get_transcription_estimate(audio_duration_seconds: f64) -> Result<Option<Tran
     Ok(estimate_transcription_time(&stats, audio_duration_seconds))
 }
 
+#[tauri::command]
+fn get_storage_stats() -> Result<StorageStats, String> {
+    recording::collect_storage_stats()
+}
+
+#[tauri::command]
+fn start_compression_batch(
+    state: State<AppState>,
+    app: tauri::AppHandle,
+    threshold_days_override: Option<u32>,
+) -> Result<(), String> {
+    let progress = Arc::clone(&state.inner().batch_progress);
+    let recording = Arc::clone(&state.inner().recording);
+    let emitter = TauriBatchEmitter { app };
+    recording::start_batch_compression(progress, recording, threshold_days_override, emitter)
+}
+
+#[tauri::command]
+fn cancel_compression_batch(state: State<AppState>) -> Result<(), String> {
+    let progress = Arc::clone(&state.inner().batch_progress);
+    request_cancel_batch(progress)
+}
+
+#[tauri::command]
+fn get_compression_progress(state: State<AppState>) -> Result<BatchProgress, String> {
+    let guard = state
+        .inner()
+        .batch_progress
+        .lock()
+        .map_err(|e| e.to_string())?;
+    Ok(guard.clone())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   let app_state = AppState {
       recording: Arc::new(Mutex::new(RecordingState::new())),
+      batch_progress: new_shared_progress(),
   };
 
   tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
     .manage(app_state)
+    .on_menu_event(|app, event| app_menu::handle_menu_event(app, event))
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -185,8 +253,53 @@ pub fn run() {
         )?;
       }
 
+      let menu = app_menu::build_app_menu(app.handle())?;
+      app.set_menu(menu)?;
+
       // Initialize storage directory
       recording::get_storage_dir()?;
+
+      // Best-effort: heal any session-index / disk drift left over by an
+      // interrupted compression run from a previous session.
+      match recording::repair_orphaned_session_references() {
+          Ok(report) => {
+              if report.session_paths_patched > 0 || report.stale_temp_files_removed > 0 {
+                  log::info!(
+                      "Orphan repair at startup: patched {} session paths, removed {} stale temp files",
+                      report.session_paths_patched,
+                      report.stale_temp_files_removed
+                  );
+              }
+          }
+          Err(e) => log::warn!("Orphan repair skipped: {}", e),
+      }
+
+      // Scenario 2 from the PRD: if the user has age-based compression
+      // enabled, kick off a background sweep a few seconds after startup so
+      // the rest of the app comes up snappily.
+      if let Ok(config) = recording::load_config() {
+          if config.audio_compression.compress_old_recordings_enabled
+              && !config.ffmpeg_path.trim().is_empty()
+          {
+              let app_handle = app.handle().clone();
+              std::thread::spawn(move || {
+                  std::thread::sleep(std::time::Duration::from_secs(5));
+                  if let Some(state) = app_handle.try_state::<AppState>() {
+                      let emitter = TauriBatchEmitter {
+                          app: app_handle.clone(),
+                      };
+                      let progress = Arc::clone(&state.batch_progress);
+                      let recording = Arc::clone(&state.recording);
+                      // Startup sweep uses the configured threshold (None = read from config).
+                      if let Err(e) = recording::start_batch_compression(
+                          progress, recording, None, emitter,
+                      ) {
+                          log::warn!("Startup compression sweep skipped: {}", e);
+                      }
+                  }
+              });
+          }
+      }
 
       Ok(())
     })
@@ -201,11 +314,17 @@ pub fn run() {
         get_recording_status,
         get_audio_levels,
         load_config,
+        save_config,
+        validate_config_path,
         load_transcript,
         copy_transcript_to_clipboard,
         retranscribe_session,
         get_app_version,
-        get_transcription_estimate
+        get_transcription_estimate,
+        get_storage_stats,
+        start_compression_batch,
+        cancel_compression_batch,
+        get_compression_progress
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src-tauri/src/recording/compression/atomic_replace.rs
+++ b/src-tauri/src/recording/compression/atomic_replace.rs
@@ -1,0 +1,187 @@
+use super::errors::CompressionError;
+use crate::recording::session::storage::update_session;
+use crate::recording::utils::get_storage_dir;
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+
+/// Outcome of a successful atomic replacement.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplacementOutcome {
+    pub wav_bytes_before: u64,
+    pub m4a_bytes_after: u64,
+    pub new_audio_path: String,
+}
+
+/// Replace a session's WAV file with a verified compressed M4A, updating
+/// `sessions.json` in the process.
+///
+/// **Ordering matters.** The sequence is chosen so the index never references
+/// a missing file:
+/// 1. Verify temp M4A exists.
+/// 2. Move temp M4A → final M4A path (both files on disk; index still points
+///    at the WAV — still valid).
+/// 3. Update `sessions.json` to point at the new M4A path (index now valid
+///    against the new file).
+/// 4. Delete the original WAV (best effort; retried on Windows file locks).
+///
+/// **Failure modes**:
+/// - Step 2 fails → index still points at the WAV which is untouched. Clean.
+/// - Step 3 fails → we roll the M4A back (remove the file we just placed),
+///   returning the disk to its pre-call state. Clean.
+/// - Step 4 fails → index already points at the M4A, so the session row is
+///   valid; the leftover WAV becomes orphan data and gets swept up by
+///   `orphan_repair` at next startup. We log a warning and treat the call as
+///   successful.
+///
+/// The intentional asymmetry: we prefer "extra file on disk" over "session
+/// index points at a deleted file". A small amount of leaked WAV is recoverable
+/// at startup; a dangling reference in `sessions.json` would surface as a
+/// user-visible broken session row.
+pub fn replace_wav_with_compressed(
+    session_id: &str,
+    wav_relative_path: &str,
+    temp_m4a_absolute: &Path,
+) -> Result<ReplacementOutcome, CompressionError> {
+    let storage_dir = get_storage_dir().map_err(|e| CompressionError::Io { message: e })?;
+    let wav_absolute = storage_dir.join(wav_relative_path);
+
+    if !temp_m4a_absolute.exists() {
+        return Err(CompressionError::Verification {
+            message: format!(
+                "Temp compressed file missing: {}",
+                temp_m4a_absolute.display()
+            ),
+        });
+    }
+    if !wav_absolute.exists() {
+        return Err(CompressionError::Io {
+            message: format!("Original WAV missing: {}", wav_absolute.display()),
+        });
+    }
+
+    let wav_bytes_before = fs::metadata(&wav_absolute)
+        .map_err(CompressionError::from)?
+        .len();
+    let m4a_bytes_after = fs::metadata(temp_m4a_absolute)
+        .map_err(CompressionError::from)?
+        .len();
+
+    let new_relative = build_relative_m4a_path(wav_relative_path);
+    let final_m4a_absolute = storage_dir.join(&new_relative);
+
+    // Move temp m4a → final m4a. If it fails we leave the WAV alone.
+    fs::rename(temp_m4a_absolute, &final_m4a_absolute).map_err(|e| {
+        // If rename fails on Windows due to a stale m4a left over from a prior run,
+        // try to remove it once and retry.
+        if final_m4a_absolute.exists() {
+            let _ = fs::remove_file(&final_m4a_absolute);
+            if fs::rename(temp_m4a_absolute, &final_m4a_absolute).is_ok() {
+                return CompressionError::Io {
+                    message: "Recovered from existing m4a at destination".to_string(),
+                };
+            }
+        }
+        CompressionError::Io {
+            message: format!("Could not move compressed file into place: {}", e),
+        }
+    })?;
+
+    // Best-effort: if we recovered above the m4a is in place. Update the index.
+    if let Err(e) = update_session(session_id, |s| {
+        s.audio_path = new_relative.clone();
+    }) {
+        // Roll back the m4a move so the index and disk stay consistent.
+        let _ = fs::remove_file(&final_m4a_absolute);
+        return Err(CompressionError::IndexUpdate { message: e });
+    }
+
+    // Now delete the WAV. Retry a few times for Windows file-lock races.
+    if let Err(e) = remove_wav_with_retry(&wav_absolute) {
+        // Index already updated — the WAV is now orphan data, but the session
+        // is in a valid state pointing at the m4a. Surface a soft warning via
+        // a tagged error, but the caller can choose to treat as success.
+        log::warn!(
+            "Compression: index updated but failed to delete original WAV at {}: {}",
+            wav_absolute.display(),
+            e
+        );
+    }
+
+    Ok(ReplacementOutcome {
+        wav_bytes_before,
+        m4a_bytes_after,
+        new_audio_path: new_relative,
+    })
+}
+
+/// Compute the relative session-store path for the compressed file given the
+/// original WAV path. Preserves the original directory so future layout
+/// changes (e.g., per-day subfolders) don't break.
+fn build_relative_m4a_path(wav_relative_path: &str) -> String {
+    let path = PathBuf::from(wav_relative_path);
+    let stem = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "session".to_string());
+    let parent = path
+        .parent()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|| "audio".to_string());
+
+    if parent.is_empty() {
+        format!("{}.m4a", stem)
+    } else {
+        format!("{}/{}.m4a", parent, stem)
+    }
+}
+
+fn remove_wav_with_retry(wav_absolute: &Path) -> Result<(), CompressionError> {
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..3 {
+        match fs::remove_file(wav_absolute) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                last_err = Some(e);
+                if attempt < 2 {
+                    thread::sleep(Duration::from_millis(200));
+                }
+            }
+        }
+    }
+    Err(CompressionError::Io {
+        message: last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown filesystem error".to_string()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_relative_m4a_path_preserves_audio_dir() {
+        assert_eq!(
+            build_relative_m4a_path("audio/2024-11-02_15-30-00.wav"),
+            "audio/2024-11-02_15-30-00.m4a"
+        );
+    }
+
+    #[test]
+    fn test_build_relative_m4a_path_no_parent_drops_to_root() {
+        // Inputs without a parent directory shouldn't invent one — preserves
+        // whatever shape the caller had on disk.
+        assert_eq!(build_relative_m4a_path("session.wav"), "session.m4a");
+    }
+
+    #[test]
+    fn test_build_relative_m4a_path_handles_nested_subfolders() {
+        assert_eq!(
+            build_relative_m4a_path("audio/2024-11/session.wav"),
+            "audio/2024-11/session.m4a"
+        );
+    }
+}

--- a/src-tauri/src/recording/compression/batch_state.rs
+++ b/src-tauri/src/recording/compression/batch_state.rs
@@ -1,0 +1,47 @@
+use serde::Serialize;
+use std::sync::{Arc, Mutex};
+
+/// High-level lifecycle of the batch compression worker. The frontend
+/// transitions UI between dialogs based on this value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BatchStatus {
+    Idle,
+    Running,
+    Cancelling,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchProgress {
+    pub status: BatchStatus,
+    pub total: u32,
+    pub current_index: u32,
+    pub current_file: Option<String>,
+    pub bytes_freed: u64,
+    pub skipped: u32,
+    pub compressed: u32,
+}
+
+impl BatchProgress {
+    pub fn idle() -> Self {
+        Self {
+            status: BatchStatus::Idle,
+            total: 0,
+            current_index: 0,
+            current_file: None,
+            bytes_freed: 0,
+            skipped: 0,
+            compressed: 0,
+        }
+    }
+}
+
+/// Thread-safe handle to the batch worker's progress. Wrapped in `Arc<Mutex<>>`
+/// so the Tauri command layer can read the current snapshot (for fallback
+/// polling) while the worker thread mutates it.
+pub type SharedBatchProgress = Arc<Mutex<BatchProgress>>;
+
+pub fn new_shared_progress() -> SharedBatchProgress {
+    Arc::new(Mutex::new(BatchProgress::idle()))
+}

--- a/src-tauri/src/recording/compression/batch_worker.rs
+++ b/src-tauri/src/recording/compression/batch_worker.rs
@@ -1,0 +1,309 @@
+use super::batch_state::{BatchProgress, BatchStatus, SharedBatchProgress};
+use super::disk_space_guard::audio_dir_is_writable;
+use super::{
+    compress_wav_to_m4a, errors::CompressionError, is_session_compressible,
+    replace_wav_with_compressed,
+};
+use crate::recording::config::load_config;
+use crate::recording::session::storage::load_sessions;
+use crate::recording::state::SharedRecordingState;
+use crate::recording::utils::get_storage_dir;
+use chrono::Utc;
+use serde::Serialize;
+use std::path::PathBuf;
+use std::thread;
+
+/// Final summary emitted when a batch run completes (or is cancelled).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchCompleteEvent {
+    pub total: u32,
+    pub compressed: u32,
+    pub skipped: u32,
+    pub bytes_freed: u64,
+    pub cancelled: bool,
+}
+
+/// Per-file progress tick emitted as the worker advances through the batch.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchProgressEvent {
+    pub total: u32,
+    pub current_index: u32,
+    pub current_file: Option<String>,
+    pub bytes_freed: u64,
+}
+
+/// Callbacks the worker invokes for progress and completion events. The
+/// Tauri command layer wires these to `app.emit(...)`.
+pub trait BatchEventEmitter: Send + 'static {
+    fn emit_progress(&self, event: BatchProgressEvent);
+    fn emit_complete(&self, event: BatchCompleteEvent);
+}
+
+/// Spawn the batch compression worker on a background thread.
+///
+/// Idempotent — if a run is already in flight, returns `Err`. Otherwise marks
+/// `progress.status = Running` synchronously before returning so callers can
+/// rely on the state having transitioned.
+///
+/// `threshold_days_override`:
+/// - `None`  → use `config.audioCompression.compressOldRecordingsOlderThanDays`
+///   (the automatic / scheduled sweep path)
+/// - `Some(n)` → bypass the config and treat any session older than `n` days
+///   as eligible. `Some(0)` means "every uncompressed WAV is eligible", which
+///   is what the in-app "Compress all WAV files" button uses.
+pub fn start_batch_compression<E: BatchEventEmitter>(
+    progress: SharedBatchProgress,
+    recording_state: SharedRecordingState,
+    threshold_days_override: Option<u32>,
+    emitter: E,
+) -> Result<(), String> {
+    {
+        let mut guard = progress.lock().map_err(|e| e.to_string())?;
+        if guard.status != BatchStatus::Idle {
+            return Err("A compression batch is already running".to_string());
+        }
+        *guard = BatchProgress {
+            status: BatchStatus::Running,
+            total: 0,
+            current_index: 0,
+            current_file: None,
+            bytes_freed: 0,
+            skipped: 0,
+            compressed: 0,
+        };
+    }
+
+    thread::spawn(move || {
+        let result = run_batch(&progress, &recording_state, threshold_days_override, &emitter);
+        finalize_batch(&progress, &emitter, result);
+    });
+
+    Ok(())
+}
+
+/// Signal an in-flight batch to stop as soon as it finishes the current file.
+pub fn request_cancel_batch(progress: SharedBatchProgress) -> Result<(), String> {
+    let mut guard = progress.lock().map_err(|e| e.to_string())?;
+    if guard.status == BatchStatus::Running {
+        guard.status = BatchStatus::Cancelling;
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct BatchTally {
+    total: u32,
+    compressed: u32,
+    skipped: u32,
+    bytes_freed: u64,
+    cancelled: bool,
+}
+
+fn run_batch<E: BatchEventEmitter>(
+    progress: &SharedBatchProgress,
+    recording_state: &SharedRecordingState,
+    threshold_days_override: Option<u32>,
+    emitter: &E,
+) -> Result<BatchTally, String> {
+    if !audio_dir_is_writable() {
+        return Err("Audio directory is not writable — cannot start batch".to_string());
+    }
+
+    let config = load_config()?;
+    let threshold_days = threshold_days_override.unwrap_or(
+        config.audio_compression.compress_old_recordings_older_than_days,
+    );
+    let ffmpeg_path = config.ffmpeg_path.clone();
+
+    let storage_dir = get_storage_dir()?;
+    let session_index = load_sessions()?;
+    let now = Utc::now();
+
+    let busy_ids: std::collections::HashSet<String> = recording_state
+        .lock()
+        .ok()
+        .map(|s| {
+            let mut set = s.transcribing_session_ids.clone();
+            if let Some(id) = s.active_session_id.clone() {
+                set.insert(id);
+            }
+            set
+        })
+        .unwrap_or_default();
+
+    let eligible: Vec<_> = session_index
+        .sessions
+        .iter()
+        .filter(|s| {
+            if busy_ids.contains(&s.id) {
+                return false;
+            }
+            is_session_compressible(s, None, threshold_days, now).is_eligible()
+        })
+        .cloned()
+        .collect();
+
+    {
+        let mut guard = progress.lock().map_err(|e| e.to_string())?;
+        guard.total = eligible.len() as u32;
+    }
+
+    let mut tally = BatchTally {
+        total: eligible.len() as u32,
+        compressed: 0,
+        skipped: 0,
+        bytes_freed: 0,
+        cancelled: false,
+    };
+
+    for (i, session) in eligible.iter().enumerate() {
+        if check_cancelled(progress) {
+            tally.cancelled = true;
+            break;
+        }
+
+        let current_index = (i as u32) + 1;
+        let current_file_name = current_file_label(&session.audio_path);
+        update_progress(progress, |p| {
+            p.current_index = current_index;
+            p.current_file = Some(current_file_name.clone());
+        });
+
+        emitter.emit_progress(BatchProgressEvent {
+            total: tally.total,
+            current_index,
+            current_file: Some(current_file_name.clone()),
+            bytes_freed: tally.bytes_freed,
+        });
+
+        let wav_absolute = storage_dir.join(&session.audio_path);
+        let mut temp_m4a = wav_absolute.clone();
+        temp_m4a.set_extension("m4a.tmp");
+
+        match compress_single_session(&ffmpeg_path, &wav_absolute, &temp_m4a, &session.id, &session.audio_path) {
+            Ok(freed) => {
+                tally.compressed += 1;
+                tally.bytes_freed += freed;
+                update_progress(progress, |p| {
+                    p.compressed += 1;
+                    p.bytes_freed += freed;
+                });
+            }
+            Err(e) => {
+                log::warn!(
+                    "Batch compression: skipped {} ({})",
+                    session.id,
+                    e
+                );
+                cleanup_temp_file(&temp_m4a);
+                tally.skipped += 1;
+                update_progress(progress, |p| {
+                    p.skipped += 1;
+                });
+            }
+        }
+    }
+
+    // Emit a final progress tick so the UI can reflect 100% before the
+    // complete event.
+    emitter.emit_progress(BatchProgressEvent {
+        total: tally.total,
+        current_index: tally.total,
+        current_file: None,
+        bytes_freed: tally.bytes_freed,
+    });
+
+    Ok(tally)
+}
+
+fn compress_single_session(
+    ffmpeg_path: &str,
+    wav_absolute: &PathBuf,
+    temp_m4a: &PathBuf,
+    session_id: &str,
+    audio_relative: &str,
+) -> Result<u64, CompressionError> {
+    compress_wav_to_m4a(ffmpeg_path, wav_absolute, temp_m4a)?;
+    let outcome = replace_wav_with_compressed(session_id, audio_relative, temp_m4a)?;
+    Ok(outcome.wav_bytes_before.saturating_sub(outcome.m4a_bytes_after))
+}
+
+fn cleanup_temp_file(temp_m4a: &PathBuf) {
+    if temp_m4a.exists() {
+        let _ = std::fs::remove_file(temp_m4a);
+    }
+}
+
+fn finalize_batch<E: BatchEventEmitter>(
+    progress: &SharedBatchProgress,
+    emitter: &E,
+    result: Result<BatchTally, String>,
+) {
+    let tally = match result {
+        Ok(t) => t,
+        Err(e) => {
+            log::error!("Batch compression aborted: {}", e);
+            BatchTally {
+                total: 0,
+                compressed: 0,
+                skipped: 0,
+                bytes_freed: 0,
+                cancelled: false,
+            }
+        }
+    };
+
+    if let Ok(mut guard) = progress.lock() {
+        guard.status = BatchStatus::Idle;
+        guard.current_file = None;
+    }
+
+    emitter.emit_complete(BatchCompleteEvent {
+        total: tally.total,
+        compressed: tally.compressed,
+        skipped: tally.skipped,
+        bytes_freed: tally.bytes_freed,
+        cancelled: tally.cancelled,
+    });
+}
+
+fn check_cancelled(progress: &SharedBatchProgress) -> bool {
+    progress
+        .lock()
+        .map(|g| g.status == BatchStatus::Cancelling)
+        .unwrap_or(false)
+}
+
+fn update_progress<F: FnOnce(&mut BatchProgress)>(progress: &SharedBatchProgress, f: F) {
+    if let Ok(mut guard) = progress.lock() {
+        f(&mut guard);
+    }
+}
+
+fn current_file_label(audio_path: &str) -> String {
+    PathBuf::from(audio_path)
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_else(|| audio_path.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_current_file_label_extracts_basename() {
+        assert_eq!(
+            current_file_label("audio/2024-11-02_15-30-00.wav"),
+            "2024-11-02_15-30-00.wav"
+        );
+    }
+
+    #[test]
+    fn test_current_file_label_falls_back_when_no_filename() {
+        // For a path that's all slashes, fall back to the raw input.
+        assert_eq!(current_file_label(""), "");
+    }
+}

--- a/src-tauri/src/recording/compression/disk_space_guard.rs
+++ b/src-tauri/src/recording/compression/disk_space_guard.rs
@@ -1,0 +1,23 @@
+use crate::recording::utils::get_storage_dir;
+use std::fs;
+
+/// Sanity check that performs a tiny write probe to confirm the audio
+/// directory is writable. We deliberately don't try to compute "free bytes" —
+/// platforms expose this very inconsistently and the value can be stale by
+/// the time we read it. The probe is good enough: if the platform can't write
+/// a 1-byte file here, the batch shouldn't start.
+pub fn audio_dir_is_writable() -> bool {
+    let storage_dir = match get_storage_dir() {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    let audio_dir = storage_dir.join("audio");
+    if !audio_dir.exists() {
+        return false;
+    }
+
+    let probe = audio_dir.join(".compression_probe");
+    let write_ok = fs::write(&probe, b"\0").is_ok();
+    let _ = fs::remove_file(&probe);
+    write_ok
+}

--- a/src-tauri/src/recording/compression/eligibility.rs
+++ b/src-tauri/src/recording/compression/eligibility.rs
@@ -1,0 +1,169 @@
+use crate::recording::models::Session;
+use chrono::{DateTime, Duration, Utc};
+use serde::Serialize;
+
+/// Result of asking whether a session is eligible for batch compression.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "reason", rename_all = "camelCase")]
+pub enum Eligibility {
+    Eligible,
+    AlreadyCompressed,
+    ActiveSession,
+    TooRecent,
+    NoAudioPath,
+    UnparseableTimestamp,
+}
+
+impl Eligibility {
+    pub fn is_eligible(&self) -> bool {
+        matches!(self, Eligibility::Eligible)
+    }
+}
+
+/// Decide whether a single session can be compressed in a batch sweep.
+///
+/// Pure function — no I/O. Tested against a wide matrix below.
+pub fn is_session_compressible(
+    session: &Session,
+    active_session_id: Option<&str>,
+    threshold_days: u32,
+    now: DateTime<Utc>,
+) -> Eligibility {
+    if session.audio_path.trim().is_empty() {
+        return Eligibility::NoAudioPath;
+    }
+
+    // Only .wav files are compression candidates. Already-.m4a files (or any
+    // other extension) get skipped silently.
+    if !session.audio_path.to_lowercase().ends_with(".wav") {
+        return Eligibility::AlreadyCompressed;
+    }
+
+    if active_session_id.is_some_and(|id| id == session.id) {
+        return Eligibility::ActiveSession;
+    }
+
+    let timestamp = match DateTime::parse_from_rfc3339(&session.timestamp) {
+        Ok(t) => t.with_timezone(&Utc),
+        Err(_) => return Eligibility::UnparseableTimestamp,
+    };
+
+    let age = now - timestamp;
+    let threshold = Duration::days(threshold_days as i64);
+
+    if age < threshold {
+        return Eligibility::TooRecent;
+    }
+
+    Eligibility::Eligible
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn session(id: &str, audio_path: &str, days_ago: i64) -> Session {
+        let timestamp = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap()
+            - Duration::days(days_ago);
+        Session {
+            id: id.to_string(),
+            timestamp: timestamp.to_rfc3339(),
+            audio_path: audio_path.to_string(),
+            duration: 30.0,
+            preview: "p".to_string(),
+            transcript_path: String::new(),
+            clipboard_copied: false,
+            transcription_time_seconds: None,
+            model_path: None,
+        }
+    }
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn test_eligible_when_old_enough() {
+        let s = session("a", "audio/a.wav", 10);
+        assert_eq!(is_session_compressible(&s, None, 7, now()), Eligibility::Eligible);
+    }
+
+    #[test]
+    fn test_too_recent_when_below_threshold() {
+        let s = session("a", "audio/a.wav", 3);
+        assert_eq!(
+            is_session_compressible(&s, None, 7, now()),
+            Eligibility::TooRecent
+        );
+    }
+
+    #[test]
+    fn test_exactly_at_threshold_is_eligible() {
+        let s = session("a", "audio/a.wav", 7);
+        // 7-day-old session with a 7-day threshold: age == threshold, so the
+        // condition `age < threshold` is false → eligible.
+        assert_eq!(
+            is_session_compressible(&s, None, 7, now()),
+            Eligibility::Eligible
+        );
+    }
+
+    #[test]
+    fn test_already_m4a_is_skipped() {
+        let s = session("a", "audio/a.m4a", 10);
+        assert_eq!(
+            is_session_compressible(&s, None, 7, now()),
+            Eligibility::AlreadyCompressed
+        );
+    }
+
+    #[test]
+    fn test_uppercase_extension_treated_correctly() {
+        let s = session("a", "audio/a.WAV", 10);
+        assert_eq!(is_session_compressible(&s, None, 7, now()), Eligibility::Eligible);
+    }
+
+    #[test]
+    fn test_active_session_is_skipped() {
+        let s = session("active-id", "audio/x.wav", 10);
+        assert_eq!(
+            is_session_compressible(&s, Some("active-id"), 7, now()),
+            Eligibility::ActiveSession
+        );
+    }
+
+    #[test]
+    fn test_different_active_id_does_not_skip() {
+        let s = session("a", "audio/a.wav", 10);
+        assert_eq!(
+            is_session_compressible(&s, Some("other-id"), 7, now()),
+            Eligibility::Eligible
+        );
+    }
+
+    #[test]
+    fn test_no_audio_path_skipped() {
+        let s = session("a", "", 10);
+        assert_eq!(
+            is_session_compressible(&s, None, 7, now()),
+            Eligibility::NoAudioPath
+        );
+    }
+
+    #[test]
+    fn test_unparseable_timestamp() {
+        let mut s = session("a", "audio/a.wav", 10);
+        s.timestamp = "not a date".to_string();
+        assert_eq!(
+            is_session_compressible(&s, None, 7, now()),
+            Eligibility::UnparseableTimestamp
+        );
+    }
+
+    #[test]
+    fn test_zero_threshold_makes_everything_eligible() {
+        let s = session("a", "audio/a.wav", 0);
+        assert_eq!(is_session_compressible(&s, None, 0, now()), Eligibility::Eligible);
+    }
+}

--- a/src-tauri/src/recording/compression/errors.rs
+++ b/src-tauri/src/recording/compression/errors.rs
@@ -1,0 +1,39 @@
+use serde::Serialize;
+use std::fmt;
+
+/// Structured failure modes for the compression pipeline.
+///
+/// The granular variants exist so the UI can decide what to surface and what
+/// to swallow (e.g., a missing FFmpeg path should prompt the user; a transient
+/// I/O error during a batch is logged and the file skipped).
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum CompressionError {
+    FfmpegMissing { message: String },
+    FfmpegFailed { message: String },
+    Verification { message: String },
+    Io { message: String },
+    IndexUpdate { message: String },
+}
+
+impl fmt::Display for CompressionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompressionError::FfmpegMissing { message }
+            | CompressionError::FfmpegFailed { message }
+            | CompressionError::Verification { message }
+            | CompressionError::Io { message }
+            | CompressionError::IndexUpdate { message } => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for CompressionError {}
+
+impl From<std::io::Error> for CompressionError {
+    fn from(value: std::io::Error) -> Self {
+        CompressionError::Io {
+            message: value.to_string(),
+        }
+    }
+}

--- a/src-tauri/src/recording/compression/ffmpeg_runner.rs
+++ b/src-tauri/src/recording/compression/ffmpeg_runner.rs
@@ -1,0 +1,130 @@
+use super::errors::CompressionError;
+use std::path::Path;
+use std::process::Command;
+
+/// Run FFmpeg to convert a WAV file at `wav_path` into an M4A (AAC) file at
+/// `m4a_temp_path`. `m4a_temp_path` is expected to be a temp location — the
+/// caller is responsible for the atomic-move step (see `atomic_replace`).
+///
+/// Settings: AAC at 64 kbps with `+faststart` for fast playback seek. Good
+/// quality for voice while delivering the ~10x size reduction the PRD targets.
+pub fn compress_wav_to_m4a(
+    ffmpeg_path: &str,
+    wav_path: &Path,
+    m4a_temp_path: &Path,
+) -> Result<(), CompressionError> {
+    if ffmpeg_path.trim().is_empty() {
+        return Err(CompressionError::FfmpegMissing {
+            message: "FFmpeg path is not configured".to_string(),
+        });
+    }
+
+    if !Path::new(ffmpeg_path).exists() {
+        return Err(CompressionError::FfmpegMissing {
+            message: format!("FFmpeg binary not found at: {}", ffmpeg_path),
+        });
+    }
+
+    if !wav_path.exists() {
+        return Err(CompressionError::Io {
+            message: format!("Source WAV not found: {}", wav_path.display()),
+        });
+    }
+
+    let output_result = build_ffmpeg_command(ffmpeg_path, wav_path, m4a_temp_path).output();
+
+    let output = output_result.map_err(|e| CompressionError::FfmpegFailed {
+        message: format!("Could not launch FFmpeg: {}", e),
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CompressionError::FfmpegFailed {
+            message: format!("FFmpeg exited with error: {}", stderr.trim()),
+        });
+    }
+
+    if !m4a_temp_path.exists() {
+        return Err(CompressionError::Verification {
+            message: "FFmpeg reported success but no output file was produced".to_string(),
+        });
+    }
+
+    // Sanity check that the output isn't a zero-byte placeholder. A real
+    // AAC/M4A file should always be more than a few bytes for any non-empty
+    // WAV. The exact threshold isn't important — 1KB rules out empty/header-only.
+    let metadata = std::fs::metadata(m4a_temp_path).map_err(CompressionError::from)?;
+    if metadata.len() < 1024 {
+        return Err(CompressionError::Verification {
+            message: format!(
+                "Compressed file is suspiciously small ({} bytes) — refusing to replace",
+                metadata.len()
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn build_ffmpeg_command(ffmpeg_path: &str, wav_path: &Path, m4a_temp_path: &Path) -> Command {
+    let mut cmd = Command::new(ffmpeg_path);
+    cmd.arg("-y") // overwrite output if it exists (temp path, safe)
+        .arg("-i")
+        .arg(wav_path)
+        .arg("-c:a")
+        .arg("aac")
+        .arg("-b:a")
+        .arg("64k")
+        .arg("-movflags")
+        .arg("+faststart")
+        // Force the M4A/MP4 muxer explicitly. We write to a `*.m4a.tmp` path
+        // and rename to `.m4a` atomically after verification; FFmpeg can't
+        // infer the format from the `.tmp` extension, so we tell it.
+        .arg("-f")
+        .arg("ipod")
+        .arg(m4a_temp_path);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_compress_returns_error_for_empty_ffmpeg_path() {
+        let wav = PathBuf::from("/tmp/whatever.wav");
+        let m4a = PathBuf::from("/tmp/whatever.m4a.tmp");
+        let err = compress_wav_to_m4a("", &wav, &m4a).unwrap_err();
+        match err {
+            CompressionError::FfmpegMissing { message } => {
+                assert!(message.contains("not configured"));
+            }
+            other => panic!("expected FfmpegMissing, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_compress_returns_error_for_nonexistent_ffmpeg_binary() {
+        let wav = PathBuf::from("/tmp/whatever.wav");
+        let m4a = PathBuf::from("/tmp/whatever.m4a.tmp");
+        let err = compress_wav_to_m4a(
+            "/definitely/does/not/exist/ffmpeg",
+            &wav,
+            &m4a,
+        )
+        .unwrap_err();
+        match err {
+            CompressionError::FfmpegMissing { .. } => {}
+            other => panic!("expected FfmpegMissing, got {:?}", other),
+        }
+    }
+}

--- a/src-tauri/src/recording/compression/mod.rs
+++ b/src-tauri/src/recording/compression/mod.rs
@@ -1,0 +1,36 @@
+//! Audio compression module.
+//!
+//! Provides building blocks for WAV → M4A conversion:
+//! - `ffmpeg_runner`: invokes FFmpeg as a subprocess
+//! - `atomic_replace`: safely swaps a verified compressed file in for the original WAV
+//! - `post_transcription`: one-shot compression entry-point called after a recording
+//!   finishes transcribing
+//! - `batch_worker` / `batch_state`: background sweep over existing recordings
+//! - `eligibility`: pure logic deciding which session files can be compressed
+//! - `storage_stats`: read-only reporting for the Settings UI
+//! - `orphan_repair`: startup reconciliation of stray temp / mis-pointed index entries
+//! - `disk_space_guard`: write-probe before kicking off a batch
+//! - `errors`: a structured error type shared across the module
+
+pub mod atomic_replace;
+pub mod batch_state;
+pub mod batch_worker;
+pub mod disk_space_guard;
+pub mod eligibility;
+pub mod errors;
+pub mod ffmpeg_runner;
+pub mod orphan_repair;
+pub mod post_transcription;
+pub mod storage_stats;
+
+pub use atomic_replace::{replace_wav_with_compressed, ReplacementOutcome};
+pub use batch_state::{new_shared_progress, BatchProgress, SharedBatchProgress};
+pub use batch_worker::{
+    request_cancel_batch, start_batch_compression, BatchCompleteEvent, BatchEventEmitter,
+    BatchProgressEvent,
+};
+pub use eligibility::is_session_compressible;
+pub use ffmpeg_runner::compress_wav_to_m4a;
+pub use orphan_repair::repair_orphaned_session_references;
+pub use post_transcription::{run_post_transcription_compression, SessionAudioCompressedEvent};
+pub use storage_stats::{collect_storage_stats, StorageStats};

--- a/src-tauri/src/recording/compression/orphan_repair.rs
+++ b/src-tauri/src/recording/compression/orphan_repair.rs
@@ -1,0 +1,144 @@
+use crate::recording::session::storage::{load_sessions, save_sessions};
+use crate::recording::utils::get_storage_dir;
+use std::fs;
+use std::path::PathBuf;
+
+/// Outcome of a single orphan-repair pass.
+#[derive(Debug, Clone, Default)]
+pub struct OrphanRepairReport {
+    pub session_paths_patched: u32,
+    pub stale_temp_files_removed: u32,
+}
+
+/// Reconcile `sessions.json` references with the audio files actually on disk
+/// and remove stray temp artefacts left behind by interrupted compression runs.
+///
+/// Specifically handles:
+/// 1. Session whose `audio_path` ends in `.wav` but the file is missing while
+///    the sibling `.m4a` exists — patch the index to point at the `.m4a`.
+/// 2. Session whose `audio_path` ends in `.m4a` but only the `.wav` exists —
+///    patch the index back to the `.wav` (rare, would mean atomic_replace was
+///    interrupted between index update and m4a rename).
+/// 3. Stale `*.m4a.tmp` files in the audio directory — delete them.
+///
+/// Best-effort: errors on individual entries are logged and skipped, never
+/// bubbled up to abort startup.
+pub fn repair_orphaned_session_references() -> Result<OrphanRepairReport, String> {
+    let storage_dir = get_storage_dir()?;
+    let audio_dir = storage_dir.join("audio");
+    let mut report = OrphanRepairReport::default();
+
+    if audio_dir.exists() {
+        report.stale_temp_files_removed = remove_stale_temp_files(&audio_dir);
+    }
+
+    let mut index = load_sessions()?;
+    let mut mutated = false;
+
+    for session in index.sessions.iter_mut() {
+        if session.audio_path.is_empty() {
+            continue;
+        }
+        let absolute = storage_dir.join(&session.audio_path);
+        if absolute.exists() {
+            continue;
+        }
+
+        if let Some(swapped) = swap_extension_path(&session.audio_path) {
+            let swapped_absolute = storage_dir.join(&swapped);
+            if swapped_absolute.exists() {
+                log::info!(
+                    "Orphan repair: patching session {} {} -> {}",
+                    session.id,
+                    session.audio_path,
+                    swapped
+                );
+                session.audio_path = swapped;
+                report.session_paths_patched += 1;
+                mutated = true;
+            }
+        }
+    }
+
+    if mutated {
+        save_sessions(&index)?;
+    }
+
+    Ok(report)
+}
+
+/// Given a `.wav` path return the sibling `.m4a` path (and vice-versa), or
+/// None if the extension isn't one we manage.
+fn swap_extension_path(audio_relative: &str) -> Option<String> {
+    let lower = audio_relative.to_lowercase();
+    if lower.ends_with(".wav") {
+        let stem = &audio_relative[..audio_relative.len() - 4];
+        Some(format!("{}.m4a", stem))
+    } else if lower.ends_with(".m4a") {
+        let stem = &audio_relative[..audio_relative.len() - 4];
+        Some(format!("{}.wav", stem))
+    } else {
+        None
+    }
+}
+
+fn remove_stale_temp_files(audio_dir: &std::path::Path) -> u32 {
+    let entries = match fs::read_dir(audio_dir) {
+        Ok(it) => it,
+        Err(_) => return 0,
+    };
+    let mut removed: u32 = 0;
+    for entry_result in entries {
+        let path: PathBuf = match entry_result {
+            Ok(e) => e.path(),
+            Err(_) => continue,
+        };
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.to_lowercase().ends_with(".m4a.tmp"))
+            .unwrap_or(false)
+        {
+            if fs::remove_file(&path).is_ok() {
+                log::info!("Orphan repair: removed stale temp {}", path.display());
+                removed += 1;
+            }
+        }
+    }
+    removed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_swap_extension_wav_to_m4a() {
+        assert_eq!(
+            swap_extension_path("audio/2024-11-02_15.wav"),
+            Some("audio/2024-11-02_15.m4a".to_string())
+        );
+    }
+
+    #[test]
+    fn test_swap_extension_m4a_to_wav() {
+        assert_eq!(
+            swap_extension_path("audio/2024-11-02_15.m4a"),
+            Some("audio/2024-11-02_15.wav".to_string())
+        );
+    }
+
+    #[test]
+    fn test_swap_extension_unknown_returns_none() {
+        assert_eq!(swap_extension_path("audio/foo.mp3"), None);
+        assert_eq!(swap_extension_path(""), None);
+    }
+
+    #[test]
+    fn test_swap_extension_case_insensitive_match() {
+        assert_eq!(
+            swap_extension_path("audio/X.WAV"),
+            Some("audio/X.m4a".to_string())
+        );
+    }
+}

--- a/src-tauri/src/recording/compression/post_transcription.rs
+++ b/src-tauri/src/recording/compression/post_transcription.rs
@@ -1,0 +1,80 @@
+use super::{
+    compress_wav_to_m4a, errors::CompressionError, replace_wav_with_compressed, ReplacementOutcome,
+};
+use crate::recording::config::load_config;
+use crate::recording::utils::get_storage_dir;
+use serde::Serialize;
+use std::path::PathBuf;
+
+/// Event payload emitted to the frontend when a session's audio file has been
+/// successfully compressed after transcription.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionAudioCompressedEvent {
+    pub session_id: String,
+    pub new_audio_path: String,
+    pub bytes_freed: u64,
+}
+
+/// Best-effort post-transcription compression of a single session.
+///
+/// Returns `Ok(Some(event))` when compression actually ran and succeeded,
+/// `Ok(None)` when the user has compression disabled (no work to do, not an
+/// error), and `Err(_)` when compression was attempted and failed. Callers
+/// should treat failures as non-fatal: the recording is preserved as WAV, the
+/// session row is valid, and the file becomes eligible for a future batch sweep.
+pub fn run_post_transcription_compression(
+    session_id: &str,
+    wav_relative_path: &str,
+) -> Result<Option<SessionAudioCompressedEvent>, CompressionError> {
+    let config = load_config().map_err(|e| CompressionError::Io { message: e })?;
+
+    if !config.audio_compression.compress_new_recordings {
+        return Ok(None);
+    }
+
+    let storage_dir = get_storage_dir().map_err(|e| CompressionError::Io { message: e })?;
+    let wav_absolute = storage_dir.join(wav_relative_path);
+
+    // Build the temp path next to the eventual final location so the atomic
+    // rename within `replace_wav_with_compressed` is on the same filesystem.
+    let temp_m4a: PathBuf = derive_temp_m4a_path(&wav_absolute);
+
+    compress_wav_to_m4a(&config.ffmpeg_path, &wav_absolute, &temp_m4a)?;
+
+    let outcome: ReplacementOutcome =
+        replace_wav_with_compressed(session_id, wav_relative_path, &temp_m4a)?;
+
+    Ok(Some(SessionAudioCompressedEvent {
+        session_id: session_id.to_string(),
+        new_audio_path: outcome.new_audio_path,
+        bytes_freed: outcome.wav_bytes_before.saturating_sub(outcome.m4a_bytes_after),
+    }))
+}
+
+/// Build the sibling temp path used during the WAV → M4A conversion.
+///
+/// We deliberately keep the temp file next to the eventual destination so that
+/// when atomic_replace renames it, both source and destination live on the
+/// same filesystem (rename across filesystems would silently degrade to a
+/// copy+delete and lose its atomicity).
+fn derive_temp_m4a_path(wav_absolute: &std::path::Path) -> PathBuf {
+    let mut temp = wav_absolute.to_path_buf();
+    temp.set_extension("m4a.tmp");
+    temp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn test_derive_temp_m4a_path_swaps_extension() {
+        let wav = Path::new("/some/dir/2024-11-02_15-30-00.wav");
+        let temp = derive_temp_m4a_path(wav);
+        assert_eq!(
+            temp.to_string_lossy(),
+            "/some/dir/2024-11-02_15-30-00.m4a.tmp"
+        );
+    }
+}

--- a/src-tauri/src/recording/compression/storage_stats.rs
+++ b/src-tauri/src/recording/compression/storage_stats.rs
@@ -1,0 +1,116 @@
+use crate::recording::utils::get_storage_dir;
+use serde::Serialize;
+use std::fs;
+
+/// Snapshot of how much disk space recordings currently occupy and how much
+/// can be reclaimed via compression. Calls drive the "Current storage" panel
+/// in the Settings UI.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageStats {
+    pub wav_count: u32,
+    pub wav_bytes: u64,
+    pub m4a_count: u32,
+    pub m4a_bytes: u64,
+    /// Heuristic estimate: a typical voice WAV compresses ~10x, so we
+    /// extrapolate ~90% of the WAV total as savings.
+    pub estimated_savings_bytes: u64,
+}
+
+/// Collect storage stats from the audio directory.
+///
+/// Best-effort: unreadable entries are silently skipped rather than aborted —
+/// we'd rather show a slightly-low number than fail the whole UI.
+pub fn collect_storage_stats() -> Result<StorageStats, String> {
+    let storage_dir = get_storage_dir()?;
+    let audio_dir = storage_dir.join("audio");
+    if !audio_dir.exists() {
+        return Ok(empty_stats());
+    }
+
+    let entries = match fs::read_dir(&audio_dir) {
+        Ok(it) => it,
+        Err(e) => return Err(format!("Could not read audio directory: {}", e)),
+    };
+
+    let mut wav_count = 0u32;
+    let mut wav_bytes = 0u64;
+    let mut m4a_count = 0u32;
+    let mut m4a_bytes = 0u64;
+
+    for entry_result in entries {
+        let entry = match entry_result {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let extension = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default();
+
+        let size = match fs::metadata(&path) {
+            Ok(m) => m.len(),
+            Err(_) => continue,
+        };
+
+        match extension.as_str() {
+            "wav" => {
+                wav_count += 1;
+                wav_bytes += size;
+            }
+            "m4a" => {
+                m4a_count += 1;
+                m4a_bytes += size;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(StorageStats {
+        wav_count,
+        wav_bytes,
+        m4a_count,
+        m4a_bytes,
+        estimated_savings_bytes: estimate_savings(wav_bytes),
+    })
+}
+
+fn empty_stats() -> StorageStats {
+    StorageStats {
+        wav_count: 0,
+        wav_bytes: 0,
+        m4a_count: 0,
+        m4a_bytes: 0,
+        estimated_savings_bytes: 0,
+    }
+}
+
+fn estimate_savings(wav_bytes: u64) -> u64 {
+    // 90% reduction is the PRD's headline number for 16kHz mono → AAC.
+    wav_bytes.saturating_mul(9) / 10
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_savings_is_ninety_percent() {
+        assert_eq!(estimate_savings(1000), 900);
+        assert_eq!(estimate_savings(0), 0);
+        assert_eq!(estimate_savings(10), 9);
+    }
+
+    #[test]
+    fn test_empty_stats_is_zero() {
+        let s = empty_stats();
+        assert_eq!(s.wav_count, 0);
+        assert_eq!(s.wav_bytes, 0);
+        assert_eq!(s.estimated_savings_bytes, 0);
+    }
+}

--- a/src-tauri/src/recording/config/loader.rs
+++ b/src-tauri/src/recording/config/loader.rs
@@ -1,26 +1,18 @@
-use crate::recording::models::WhisperConfig;
+use crate::recording::models::AppConfig;
 use crate::recording::utils::get_storage_dir;
 use std::fs;
 
-/// Load the Whisper configuration from the config.json file
+/// Load the application configuration from `config.json`.
 ///
-/// Returns an error with helpful setup instructions if the config file
-/// doesn't exist or can't be parsed
-pub fn load_config() -> Result<WhisperConfig, String> {
+/// Returns `AppConfig::default()` if the file does not exist yet (fresh install
+/// or pre-Settings-panel migration). Older configs with only whisperPath/modelPath
+/// keep working — newly added fields fall back to defaults.
+pub fn load_config() -> Result<AppConfig, String> {
     let storage_dir = get_storage_dir()?;
     let config_file = storage_dir.join("config.json");
 
     if !config_file.exists() {
-        return Err(format!(
-            "Whisper.cpp is not set up. Please create config.json at: {}\n\
-            See README for setup instructions.\n\
-            Example content:\n\
-            {{\n\
-              \"whisperPath\": \"C:\\\\whisper\\\\whisper.exe\",\n\
-              \"modelPath\": \"C:\\\\whisper\\\\models\\\\ggml-base.bin\"\n\
-            }}",
-            config_file.display()
-        ));
+        return Ok(AppConfig::default());
     }
 
     let content = fs::read_to_string(&config_file)
@@ -32,7 +24,7 @@ pub fn load_config() -> Result<WhisperConfig, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::recording::models::AppConfig;
 
     #[test]
     fn test_parse_valid_config() {
@@ -41,13 +33,11 @@ mod tests {
             "modelPath": "/models/ggml-base.bin"
         }"#;
 
-        let config: Result<WhisperConfig, _> = serde_json::from_str(json);
-        assert!(config.is_ok());
-
-        let config = config.unwrap();
+        let config: AppConfig = serde_json::from_str(json).expect("should parse");
         assert_eq!(config.whisper_path, "/usr/local/bin/whisper-cli");
         assert_eq!(config.model_path, "/models/ggml-base.bin");
         assert_eq!(config.voice_notes_dir, None);
+        assert_eq!(config.ffmpeg_path, "");
     }
 
     #[test]
@@ -58,10 +48,7 @@ mod tests {
             "voiceNotesDir": "/custom/notes"
         }"#;
 
-        let config: Result<WhisperConfig, _> = serde_json::from_str(json);
-        assert!(config.is_ok());
-
-        let config = config.unwrap();
+        let config: AppConfig = serde_json::from_str(json).expect("should parse");
         assert_eq!(config.voice_notes_dir, Some("/custom/notes".to_string()));
     }
 
@@ -72,18 +59,21 @@ mod tests {
             "modelPath": "/models/ggml-base.bin"
         }"#;
 
-        let config: Result<WhisperConfig, _> = serde_json::from_str(json);
-        assert!(config.is_err());
+        let result: Result<AppConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
     }
 
     #[test]
-    fn test_parse_missing_required_fields() {
+    fn test_parse_partial_config_uses_defaults() {
+        // Missing required-looking fields default to empty strings now —
+        // validation happens at the call site (Settings panel), not at load time.
         let json = r#"{
             "whisperPath": "/usr/local/bin/whisper-cli"
         }"#;
 
-        let config: Result<WhisperConfig, _> = serde_json::from_str(json);
-        assert!(config.is_err());
+        let config: AppConfig = serde_json::from_str(json).expect("should parse");
+        assert_eq!(config.whisper_path, "/usr/local/bin/whisper-cli");
+        assert_eq!(config.model_path, "");
     }
 
     #[test]
@@ -93,10 +83,7 @@ mod tests {
             "modelPath": "C:\\whisper\\models\\ggml-base.bin"
         }"#;
 
-        let config: Result<WhisperConfig, _> = serde_json::from_str(json);
-        assert!(config.is_ok());
-
-        let config = config.unwrap();
+        let config: AppConfig = serde_json::from_str(json).expect("should parse");
         assert_eq!(config.whisper_path, "C:\\whisper\\whisper.exe");
         assert_eq!(config.model_path, "C:\\whisper\\models\\ggml-base.bin");
     }
@@ -109,7 +96,7 @@ mod tests {
             "extraField": "should be ignored"
         }"#;
 
-        let config: Result<WhisperConfig, _> = serde_json::from_str(json);
-        assert!(config.is_ok());
+        let result: Result<AppConfig, _> = serde_json::from_str(json);
+        assert!(result.is_ok());
     }
 }

--- a/src-tauri/src/recording/config/mod.rs
+++ b/src-tauri/src/recording/config/mod.rs
@@ -1,3 +1,7 @@
 pub mod loader;
+pub mod path_validator;
+pub mod persister;
 
 pub use loader::load_config;
+pub use path_validator::{validate_path, PathKind, PathValidation};
+pub use persister::save_config;

--- a/src-tauri/src/recording/config/path_validator.rs
+++ b/src-tauri/src/recording/config/path_validator.rs
@@ -1,0 +1,212 @@
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
+
+/// What kind of file we're validating — drives which checks to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PathKind {
+    /// An executable binary that should respond to `--version` or `-version`.
+    Executable,
+    /// A regular data file (e.g., the Whisper model `.bin`).
+    File,
+    /// Specifically the FFmpeg executable — runs `ffmpeg -version` to detect.
+    Ffmpeg,
+}
+
+/// Result of validating a configured path.
+///
+/// `exists` and `kind_ok` are independent: a path can exist but be the wrong
+/// kind (a directory where a binary was expected), or the right kind but missing.
+#[derive(Debug, Clone, Serialize)]
+pub struct PathValidation {
+    pub exists: bool,
+    pub kind_ok: bool,
+    pub version: Option<String>,
+    pub message: String,
+}
+
+impl PathValidation {
+    fn missing() -> Self {
+        Self {
+            exists: false,
+            kind_ok: false,
+            version: None,
+            message: "File does not exist at the given path".to_string(),
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            exists: false,
+            kind_ok: false,
+            version: None,
+            message: "Path is empty".to_string(),
+        }
+    }
+}
+
+/// Validate a configured path according to its expected kind.
+///
+/// Pure entry point for both the Settings panel "is this configured correctly?"
+/// status indicator and pre-flight checks before running Whisper or FFmpeg.
+pub fn validate_path(path: &str, kind: PathKind) -> PathValidation {
+    if path.trim().is_empty() {
+        return PathValidation::empty();
+    }
+
+    let p = Path::new(path);
+    if !p.exists() {
+        return PathValidation::missing();
+    }
+
+    if !p.is_file() {
+        return PathValidation {
+            exists: true,
+            kind_ok: false,
+            version: None,
+            message: "Path exists but is not a file".to_string(),
+        };
+    }
+
+    match kind {
+        PathKind::File => PathValidation {
+            exists: true,
+            kind_ok: true,
+            version: None,
+            message: "File found".to_string(),
+        },
+        PathKind::Executable => PathValidation {
+            exists: true,
+            kind_ok: true,
+            version: None,
+            message: "Executable found".to_string(),
+        },
+        PathKind::Ffmpeg => detect_ffmpeg_version(path),
+    }
+}
+
+/// Probe an ffmpeg binary by running `ffmpeg -version` and parsing the first line.
+///
+/// We don't fail validation if version parsing fails — the binary running at all
+/// is the meaningful signal.
+fn detect_ffmpeg_version(path: &str) -> PathValidation {
+    let output_result = build_ffmpeg_version_command(path).output();
+
+    let output = match output_result {
+        Ok(o) => o,
+        Err(_) => {
+            return PathValidation {
+                exists: true,
+                kind_ok: false,
+                version: None,
+                message: "Found a file at this path but it failed to launch as a process"
+                    .to_string(),
+            };
+        }
+    };
+
+    if !output.status.success() {
+        return PathValidation {
+            exists: true,
+            kind_ok: false,
+            version: None,
+            message: "Binary launched but did not respond to `-version` — is this FFmpeg?"
+                .to_string(),
+        };
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let version = parse_ffmpeg_version_line(&stdout);
+    let message = version
+        .as_ref()
+        .map(|v| format!("FFmpeg detected ({})", v))
+        .unwrap_or_else(|| "FFmpeg detected".to_string());
+
+    PathValidation {
+        exists: true,
+        kind_ok: true,
+        version,
+        message,
+    }
+}
+
+fn build_ffmpeg_version_command(path: &str) -> Command {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        let mut cmd = Command::new(path);
+        cmd.arg("-version").creation_flags(CREATE_NO_WINDOW);
+        cmd
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let mut cmd = Command::new(path);
+        cmd.arg("-version");
+        cmd
+    }
+}
+
+/// Parse the first non-empty line of `ffmpeg -version` output to extract the
+/// version token (e.g., "ffmpeg version 6.1.1-essentials_build-www.gyan.dev").
+pub fn parse_ffmpeg_version_line(stdout: &str) -> Option<String> {
+    let first_line = stdout.lines().find(|l| !l.trim().is_empty())?;
+    // Typical format: "ffmpeg version 6.1 Copyright (c) 2000-2023 ..."
+    let after_prefix = first_line.strip_prefix("ffmpeg version ")?;
+    let token = after_prefix.split_whitespace().next()?;
+    Some(token.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_path_returns_empty_validation() {
+        let v = validate_path("", PathKind::Executable);
+        assert!(!v.exists);
+        assert!(!v.kind_ok);
+        assert!(v.message.contains("empty"));
+    }
+
+    #[test]
+    fn test_whitespace_only_path_treated_as_empty() {
+        let v = validate_path("   ", PathKind::Executable);
+        assert!(!v.exists);
+        assert!(v.message.contains("empty"));
+    }
+
+    #[test]
+    fn test_missing_path_returns_missing_validation() {
+        let v = validate_path("/definitely/does/not/exist/ffmpeg", PathKind::Ffmpeg);
+        assert!(!v.exists);
+        assert!(!v.kind_ok);
+    }
+
+    #[test]
+    fn test_parse_ffmpeg_version_line_standard_format() {
+        let stdout = "ffmpeg version 6.1 Copyright (c) 2000-2023 the FFmpeg developers\nbuilt with ...";
+        assert_eq!(parse_ffmpeg_version_line(stdout), Some("6.1".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ffmpeg_version_line_windows_build() {
+        let stdout = "ffmpeg version n6.1.1-essentials_build-www.gyan.dev Copyright (c) ...\n";
+        assert_eq!(
+            parse_ffmpeg_version_line(stdout),
+            Some("n6.1.1-essentials_build-www.gyan.dev".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_ffmpeg_version_line_unrecognized() {
+        let stdout = "some other tool version 1.0\n";
+        assert_eq!(parse_ffmpeg_version_line(stdout), None);
+    }
+
+    #[test]
+    fn test_parse_ffmpeg_version_line_empty() {
+        assert_eq!(parse_ffmpeg_version_line(""), None);
+    }
+}

--- a/src-tauri/src/recording/config/persister.rs
+++ b/src-tauri/src/recording/config/persister.rs
@@ -1,0 +1,69 @@
+use crate::recording::models::AppConfig;
+use crate::recording::utils::get_storage_dir;
+use std::fs;
+
+/// Persist application configuration to `config.json` atomically.
+///
+/// Writes to `config.json.tmp` first then renames over the real file so a crash
+/// mid-write can never leave the user with a half-written config (we'd rather
+/// keep the old config than corrupt it).
+pub fn save_config(config: &AppConfig) -> Result<(), String> {
+    let storage_dir = get_storage_dir()?;
+    let final_path = storage_dir.join("config.json");
+    let temp_path = storage_dir.join("config.json.tmp");
+
+    let content = serde_json::to_string_pretty(config)
+        .map_err(|e| format!("Failed to serialize config: {}", e))?;
+
+    fs::write(&temp_path, content)
+        .map_err(|e| format!("Failed to write config temp file: {}", e))?;
+
+    fs::rename(&temp_path, &final_path)
+        .map_err(|e| format!("Failed to finalize config file: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recording::models::AudioCompressionConfig;
+
+    #[test]
+    fn test_serialize_pretty_round_trip() {
+        let config = AppConfig {
+            whisper_path: "/bin/whisper".into(),
+            model_path: "/models/base.bin".into(),
+            voice_notes_dir: None,
+            ffmpeg_path: "/bin/ffmpeg".into(),
+            audio_compression: AudioCompressionConfig {
+                compress_new_recordings: true,
+                compress_old_recordings_enabled: false,
+                compress_old_recordings_older_than_days: 14,
+            },
+        };
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        // The pretty form should have newlines and the camelCase field names.
+        assert!(json.contains("\n"));
+        assert!(json.contains("\"whisperPath\""));
+        assert!(json.contains("\"ffmpegPath\""));
+        assert!(json.contains("\"compressNewRecordings\": true"));
+
+        let parsed: AppConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.whisper_path, "/bin/whisper");
+        assert_eq!(parsed.ffmpeg_path, "/bin/ffmpeg");
+        assert!(parsed.audio_compression.compress_new_recordings);
+        assert_eq!(
+            parsed.audio_compression.compress_old_recordings_older_than_days,
+            14
+        );
+    }
+
+    #[test]
+    fn test_voice_notes_dir_omitted_when_none() {
+        let config = AppConfig::default();
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("voiceNotesDir"));
+    }
+}

--- a/src-tauri/src/recording/mod.rs
+++ b/src-tauri/src/recording/mod.rs
@@ -1,5 +1,6 @@
 // Core modules
 mod audio;
+mod compression;
 mod config;
 mod models;
 mod session;
@@ -12,14 +13,21 @@ mod utils;
 
 // Data models
 pub use models::{
-    Session, SessionIndex, TranscriptionCompleteEvent, TranscriptionErrorEvent, WhisperConfig,
+    AppConfig, Session, SessionIndex, TranscriptionCompleteEvent, TranscriptionErrorEvent,
 };
 
 // State management
 pub use state::{RecordingState, RecordingStatus, SharedRecordingState};
 
 // Configuration
-pub use config::load_config;
+pub use config::{load_config, save_config, validate_path, PathKind, PathValidation};
+
+// Compression pipeline
+pub use compression::{
+    collect_storage_stats, new_shared_progress, repair_orphaned_session_references,
+    request_cancel_batch, start_batch_compression, BatchCompleteEvent, BatchEventEmitter,
+    BatchProgress, BatchProgressEvent, SharedBatchProgress, StorageStats,
+};
 
 // Session operations (main API surface)
 pub use session::{

--- a/src-tauri/src/recording/models.rs
+++ b/src-tauri/src/recording/models.rs
@@ -26,16 +26,72 @@ pub struct SessionIndex {
     pub sessions: Vec<Session>,
 }
 
-/// Configuration for Whisper.cpp integration
+/// Audio compression behavior settings, persisted under `audioCompression` in config.json
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WhisperConfig {
-    #[serde(rename = "whisperPath")]
-    pub whisper_path: String,
-    #[serde(rename = "modelPath")]
-    pub model_path: String,
-    #[serde(rename = "voiceNotesDir")]
-    pub voice_notes_dir: Option<String>,
+pub struct AudioCompressionConfig {
+    #[serde(rename = "compressNewRecordings", default = "default_compress_new_recordings")]
+    pub compress_new_recordings: bool,
+    #[serde(rename = "compressOldRecordingsEnabled", default)]
+    pub compress_old_recordings_enabled: bool,
+    #[serde(
+        rename = "compressOldRecordingsOlderThanDays",
+        default = "default_compress_threshold_days"
+    )]
+    pub compress_old_recordings_older_than_days: u32,
 }
+
+fn default_compress_new_recordings() -> bool {
+    true
+}
+
+fn default_compress_threshold_days() -> u32 {
+    7
+}
+
+impl Default for AudioCompressionConfig {
+    fn default() -> Self {
+        Self {
+            compress_new_recordings: default_compress_new_recordings(),
+            compress_old_recordings_enabled: false,
+            compress_old_recordings_older_than_days: default_compress_threshold_days(),
+        }
+    }
+}
+
+/// Persisted application configuration
+///
+/// Loaded from / saved to `~/Documents/ThoughtCast/config.json`. New fields
+/// (ffmpegPath, audioCompression) default sensibly so older config files keep
+/// working without manual migration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppConfig {
+    #[serde(rename = "whisperPath", default)]
+    pub whisper_path: String,
+    #[serde(rename = "modelPath", default)]
+    pub model_path: String,
+    #[serde(rename = "voiceNotesDir", skip_serializing_if = "Option::is_none")]
+    pub voice_notes_dir: Option<String>,
+    #[serde(rename = "ffmpegPath", default)]
+    pub ffmpeg_path: String,
+    #[serde(rename = "audioCompression", default)]
+    pub audio_compression: AudioCompressionConfig,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            whisper_path: String::new(),
+            model_path: String::new(),
+            voice_notes_dir: None,
+            ffmpeg_path: String::new(),
+            audio_compression: AudioCompressionConfig::default(),
+        }
+    }
+}
+
+/// Backwards-compatible alias for code that still references the old type name.
+/// Prefer `AppConfig` in new code.
+pub type WhisperConfig = AppConfig;
 
 /// Event payload for transcription completion
 #[derive(Debug, Clone, Serialize)]
@@ -143,48 +199,105 @@ mod tests {
     }
 
     #[test]
-    fn test_whisper_config_serialization() {
-        let config = WhisperConfig {
+    fn test_app_config_full_serialization_round_trip() {
+        let config = AppConfig {
             whisper_path: "/path/to/whisper".to_string(),
             model_path: "/path/to/model.bin".to_string(),
             voice_notes_dir: Some("/path/to/notes".to_string()),
+            ffmpeg_path: "/usr/local/bin/ffmpeg".to_string(),
+            audio_compression: AudioCompressionConfig {
+                compress_new_recordings: true,
+                compress_old_recordings_enabled: true,
+                compress_old_recordings_older_than_days: 30,
+            },
         };
 
         let json = serde_json::to_string(&config).unwrap();
-        let deserialized: WhisperConfig = serde_json::from_str(&json).unwrap();
+        let deserialized: AppConfig = serde_json::from_str(&json).unwrap();
 
         assert_eq!(deserialized.whisper_path, config.whisper_path);
         assert_eq!(deserialized.model_path, config.model_path);
         assert_eq!(deserialized.voice_notes_dir, config.voice_notes_dir);
+        assert_eq!(deserialized.ffmpeg_path, config.ffmpeg_path);
+        assert!(deserialized.audio_compression.compress_new_recordings);
+        assert!(deserialized.audio_compression.compress_old_recordings_enabled);
+        assert_eq!(
+            deserialized
+                .audio_compression
+                .compress_old_recordings_older_than_days,
+            30
+        );
     }
 
     #[test]
-    fn test_whisper_config_camel_case_fields() {
-        // Test that JSON uses camelCase as expected by frontend
+    fn test_app_config_camel_case_fields() {
         let json = r#"{
             "whisperPath": "/usr/bin/whisper",
             "modelPath": "/models/base.bin",
-            "voiceNotesDir": "/notes"
+            "voiceNotesDir": "/notes",
+            "ffmpegPath": "/bin/ffmpeg",
+            "audioCompression": {
+                "compressNewRecordings": true,
+                "compressOldRecordingsEnabled": false,
+                "compressOldRecordingsOlderThanDays": 14
+            }
         }"#;
 
-        let config: WhisperConfig = serde_json::from_str(json).unwrap();
+        let config: AppConfig = serde_json::from_str(json).unwrap();
 
         assert_eq!(config.whisper_path, "/usr/bin/whisper");
         assert_eq!(config.model_path, "/models/base.bin");
         assert_eq!(config.voice_notes_dir, Some("/notes".to_string()));
+        assert_eq!(config.ffmpeg_path, "/bin/ffmpeg");
+        assert!(config.audio_compression.compress_new_recordings);
+        assert!(!config.audio_compression.compress_old_recordings_enabled);
+        assert_eq!(
+            config
+                .audio_compression
+                .compress_old_recordings_older_than_days,
+            14
+        );
     }
 
     #[test]
-    fn test_whisper_config_optional_voice_notes_dir() {
+    fn test_legacy_two_field_config_still_loads() {
+        // Older config.json files only had whisperPath + modelPath.
+        // Must still deserialize, with default ffmpeg + compression sections.
         let json = r#"{
             "whisperPath": "/usr/bin/whisper",
             "modelPath": "/models/base.bin"
         }"#;
 
-        let config: WhisperConfig = serde_json::from_str(json).unwrap();
+        let config: AppConfig = serde_json::from_str(json).unwrap();
 
         assert_eq!(config.whisper_path, "/usr/bin/whisper");
         assert_eq!(config.model_path, "/models/base.bin");
         assert_eq!(config.voice_notes_dir, None);
+        assert_eq!(config.ffmpeg_path, "");
+        // compress_new_recordings defaults to true so legacy configs adopt the
+        // post-transcription compression behavior automatically.
+        assert!(config.audio_compression.compress_new_recordings);
+        assert!(!config.audio_compression.compress_old_recordings_enabled);
+        assert_eq!(
+            config
+                .audio_compression
+                .compress_old_recordings_older_than_days,
+            7
+        );
+    }
+
+    #[test]
+    fn test_app_config_defaults() {
+        let config = AppConfig::default();
+        assert_eq!(config.whisper_path, "");
+        assert_eq!(config.model_path, "");
+        assert_eq!(config.ffmpeg_path, "");
+        assert!(config.audio_compression.compress_new_recordings);
+        assert_eq!(
+            config
+                .audio_compression
+                .compress_old_recordings_older_than_days,
+            7
+        );
     }
 }

--- a/src-tauri/src/recording/session/lifecycle.rs
+++ b/src-tauri/src/recording/session/lifecycle.rs
@@ -1,4 +1,5 @@
 use crate::recording::audio::{start_capture, write_wav_file};
+use crate::recording::compression::{run_post_transcription_compression, SessionAudioCompressedEvent};
 use crate::recording::models::Session;
 use crate::recording::session::storage::add_session;
 use crate::recording::state::{RecordingStatus, SharedRecordingState};
@@ -167,17 +168,52 @@ pub fn orchestrate_async_transcription<F>(
 ) where
     F: Fn(TranscriptionResult) + Send + 'static,
 {
+    // Mark the session as in-flight for transcription before the worker thread
+    // starts so the batch-compression worker won't race it.
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.transcribing_session_ids.insert(session_id.clone());
+    }
+
     thread::spawn(move || {
         let result = process_transcription_async(audio_path, session_id.clone());
 
         // Update state to idle regardless of success/failure
         if let Ok(mut state_guard) = state.lock() {
             state_guard.status = RecordingStatus::Idle;
+            state_guard.transcribing_session_ids.remove(&session_id);
         }
 
         // Emit event via injected callback
         match result {
-            Ok(session) => event_emitter(TranscriptionResult::Success(session)),
+            Ok(session) => {
+                let audio_path_for_compression = session.audio_path.clone();
+                let session_id_for_compression = session.id.clone();
+                event_emitter(TranscriptionResult::Success(session));
+
+                // Best-effort post-transcription compression. Runs on this same
+                // background thread after the success event has already fired
+                // so the UI gets a transcript first and then a follow-up
+                // compression event if compression was enabled.
+                match run_post_transcription_compression(
+                    &session_id_for_compression,
+                    &audio_path_for_compression,
+                ) {
+                    Ok(Some(compression_event)) => {
+                        event_emitter(TranscriptionResult::Compressed(compression_event));
+                    }
+                    Ok(None) => {
+                        // Compression disabled — nothing to do.
+                    }
+                    Err(e) => {
+                        // Non-fatal: WAV stays put, session row remains valid.
+                        log::warn!(
+                            "Post-transcription compression failed for {}: {}",
+                            session_id_for_compression,
+                            e
+                        );
+                    }
+                }
+            }
             Err(error) => event_emitter(TranscriptionResult::Error {
                 session_id,
                 error,
@@ -189,6 +225,7 @@ pub fn orchestrate_async_transcription<F>(
 /// Result of async transcription for event emission
 pub enum TranscriptionResult {
     Success(Session),
+    Compressed(SessionAudioCompressedEvent),
     Error { session_id: String, error: String },
 }
 

--- a/src-tauri/src/recording/session/storage.rs
+++ b/src-tauri/src/recording/session/storage.rs
@@ -67,7 +67,6 @@ pub fn add_session(session: Session) -> Result<(), String> {
 }
 
 /// Update an existing session in the index
-#[allow(dead_code)]
 pub fn update_session<F>(session_id: &str, updater: F) -> Result<(), String>
 where
     F: FnOnce(&mut Session),

--- a/src-tauri/src/recording/state.rs
+++ b/src-tauri/src/recording/state.rs
@@ -15,13 +15,19 @@ pub enum RecordingStatus {
 /// The state of an active recording session
 ///
 /// Manages the recording status, audio samples buffer, and timing information
-/// including support for pause/resume functionality
+/// including support for pause/resume functionality.
+///
+/// `active_session_id` and `transcribing_session_ids` exist so the compression
+/// worker can skip files that are mid-recording or mid-transcription. They
+/// are populated by the session lifecycle and cleared on idle.
 pub struct RecordingState {
     pub status: RecordingStatus,
     pub samples: Arc<Mutex<Vec<f32>>>,
     pub start_time: Option<DateTime<Utc>>,
     pub pause_start_time: Option<DateTime<Utc>>,
     pub total_paused_duration_ms: i64,
+    pub active_session_id: Option<String>,
+    pub transcribing_session_ids: std::collections::HashSet<String>,
 }
 
 impl RecordingState {
@@ -32,6 +38,8 @@ impl RecordingState {
             start_time: None,
             pause_start_time: None,
             total_paused_duration_ms: 0,
+            active_session_id: None,
+            transcribing_session_ids: std::collections::HashSet::new(),
         }
     }
 

--- a/src/api/ApiContext.tsx
+++ b/src/api/ApiContext.tsx
@@ -11,6 +11,14 @@ import {
   TauriClipboardService,
   TauriTranscriptionStatsService,
 } from './services';
+import {
+  ISettingsService,
+  TauriSettingsService,
+} from '../features/settings/SettingsService';
+import {
+  ICompressionService,
+  TauriCompressionService,
+} from '../features/compression/CompressionService';
 
 /**
  * API services available to the application
@@ -21,6 +29,8 @@ export interface ApiServices {
   transcriptService: ITranscriptService;
   clipboardService: IClipboardService;
   transcriptionStatsService: ITranscriptionStatsService;
+  settingsService: ISettingsService;
+  compressionService: ICompressionService;
 }
 
 /**
@@ -66,6 +76,8 @@ export function ApiProvider({ children, services }: ApiProviderProps) {
       transcriptService: new TauriTranscriptService(),
       clipboardService: new TauriClipboardService(),
       transcriptionStatsService: new TauriTranscriptionStatsService(),
+      settingsService: new TauriSettingsService(),
+      compressionService: new TauriCompressionService(),
     }),
     []
   );

--- a/src/api/CompressionEvents.ts
+++ b/src/api/CompressionEvents.ts
@@ -1,0 +1,37 @@
+/**
+ * Tauri events emitted by the compression pipeline / batch worker.
+ *
+ * Lives in `src/api/` (not `src/features/compression/`) because these constants
+ * cross feature boundaries: both `useCompressionBatch` (in features/compression)
+ * and `useRecordingWorkflow` (in app/) subscribe to them. Mirrors the layout
+ * of `TranscriptionEvents.ts`.
+ *
+ * The string literals match the strings emitted from `src-tauri/src/lib.rs`.
+ * Keep this file as the single source of truth on the frontend so a typo
+ * can't drift.
+ */
+
+export const SESSION_AUDIO_COMPRESSED = "session-audio-compressed" as const;
+export const COMPRESSION_BATCH_PROGRESS = "compression-batch-progress" as const;
+export const COMPRESSION_BATCH_COMPLETE = "compression-batch-complete" as const;
+
+export interface SessionAudioCompressedPayload {
+  session_id: string;
+  new_audio_path: string;
+  bytes_freed: number;
+}
+
+export interface CompressionBatchProgressPayload {
+  total: number;
+  currentIndex: number;
+  currentFile: string | null;
+  bytesFreed: number;
+}
+
+export interface CompressionBatchCompletePayload {
+  total: number;
+  compressed: number;
+  skipped: number;
+  bytesFreed: number;
+  cancelled: boolean;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,16 @@ export type {
   TranscriptionCompleteEvent,
   TranscriptionErrorEvent,
 } from './TranscriptionEvents';
+export {
+  SESSION_AUDIO_COMPRESSED,
+  COMPRESSION_BATCH_PROGRESS,
+  COMPRESSION_BATCH_COMPLETE,
+} from './CompressionEvents';
+export type {
+  SessionAudioCompressedPayload,
+  CompressionBatchProgressPayload,
+  CompressionBatchCompletePayload,
+} from './CompressionEvents';
 export type {
   TranscriptionEstimate,
   TranscriptionProgress,

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,22 @@
 import SessionList from "../features/sessions/SessionList";
 import SessionViewer from "../features/sessions/SessionViewer";
+import SettingsPanel from "../features/settings/SettingsPanel";
+import { useSettingsPanel } from "../features/settings/useSettingsPanel";
+import { useCompressionBatch } from "../features/compression/useCompressionBatch";
+import CompressionProgressDialog from "../features/compression/CompressionProgressDialog";
+import CompressionCompletionToast from "../features/compression/CompressionCompletionToast";
+import CompressionStorageSummary from "../features/compression/CompressionStorageSummary";
 import { useRecordingWorkflow } from "./useRecordingWorkflow";
 import { useAppVersion } from "./useAppVersion";
+import { useState } from "react";
 import "./App.css";
 
 function App() {
-  // Set app version in window title
   useAppVersion();
+
+  const settingsPanel = useSettingsPanel();
+  const compressionBatch = useCompressionBatch();
+  const [progressDialogHidden, setProgressDialogHidden] = useState(false);
 
   const {
     sessions,
@@ -22,8 +32,16 @@ function App() {
     handleCancelRecording,
     handleStopRecording,
     setSelectedId,
-    loadSessions
+    loadSessions,
   } = useRecordingWorkflow();
+
+  const handleCompressNow = async () => {
+    // Manual button always compresses every uncompressed WAV. The configured
+    // age threshold only governs the automatic startup sweep — see
+    // `start_batch_compression` in the Rust side.
+    setProgressDialogHidden(false);
+    await compressionBatch.start({ ignoreThreshold: true });
+  };
 
   return (
     <div className="app">
@@ -45,6 +63,48 @@ function App() {
         onStopRecording={handleStopRecording}
         onSessionsChanged={loadSessions}
       />
+      <SettingsPanel
+        isOpen={settingsPanel.isOpen}
+        onClose={() => {
+          settingsPanel.close();
+          void compressionBatch.refreshStorage();
+        }}
+        renderCompressionExtras={(form) => ({
+          onCompressNow: form.draft.ffmpegPath ? handleCompressNow : undefined,
+          compressNowDisabledReason: compressionBatch.getCompressNowDisabledReason(
+            Boolean(form.draft.ffmpegPath)
+          ),
+          storageSummary: (
+            <CompressionStorageSummary stats={compressionBatch.storage} />
+          ),
+        })}
+      />
+      {/*
+        Gate on `total > 0`, not just `isRunning`: the backend flips to
+        Running synchronously before the worker thread has decided whether
+        anything is eligible. Without this gate, a startup auto-sweep (or a
+        manual press with no eligible files) briefly flashes a "0 of 0"
+        dialog. With it, the dialog only appears once the worker has actual
+        work queued up.
+      */}
+      {compressionBatch.isRunning &&
+        compressionBatch.progress.total > 0 &&
+        !progressDialogHidden && (
+          <CompressionProgressDialog
+            progress={compressionBatch.progress}
+            onRunInBackground={() => setProgressDialogHidden(true)}
+            onCancel={compressionBatch.cancel}
+          />
+        )}
+      {compressionBatch.lastCompletion && (
+        <CompressionCompletionToast
+          summary={compressionBatch.lastCompletion}
+          onDismiss={() => {
+            compressionBatch.dismissCompletion();
+            void loadSessions();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/useRecordingWorkflow.test.ts
+++ b/src/app/useRecordingWorkflow.test.ts
@@ -234,6 +234,8 @@ describe('useRecordingWorkflow', () => {
           clipboardService: mockClipboardService as any,
           transcriptService: mockTranscriptService as any,
           transcriptionStatsService: {} as any,
+          settingsService: {} as any,
+          compressionService: {} as any,
         },
       }
     );

--- a/src/app/useRecordingWorkflow.ts
+++ b/src/app/useRecordingWorkflow.ts
@@ -4,6 +4,8 @@ import {
   RecordingStatus,
   TranscriptionCompleteEvent,
   TranscriptionErrorEvent,
+  SESSION_AUDIO_COMPRESSED,
+  SessionAudioCompressedPayload,
   useApi,
 } from '../api';
 import { listen } from '@tauri-apps/api/event';
@@ -249,10 +251,23 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
         (event) => handleTranscriptionError(event.payload.session_id, event.payload.error, callbacks)
       );
 
+      // Listen for post-transcription audio compression: the session row's
+      // audio_path changed and we want the UI to refresh that row.
+      const unlistenCompressed = await listen<SessionAudioCompressedPayload>(
+        SESSION_AUDIO_COMPRESSED,
+        (event) => {
+          logger.info(
+            `Session ${event.payload.session_id} compressed; freed ${event.payload.bytes_freed} bytes`
+          );
+          void loadSessions();
+        }
+      );
+
       // Cleanup listeners on unmount
       return () => {
         unlistenComplete();
         unlistenError();
+        unlistenCompressed();
       };
     };
 

--- a/src/features/compression/CompressionCompletionToast.css
+++ b/src/features/compression/CompressionCompletionToast.css
@@ -1,0 +1,41 @@
+.compression-toast {
+  position: fixed;
+  bottom: var(--space-xl);
+  right: var(--space-xl);
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  background-color: var(--color-success);
+  color: white;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  animation: slideInRight 0.25s ease-out;
+}
+
+.compression-toast-text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.compression-toast-text strong {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+}
+
+.compression-toast-text span {
+  font-size: var(--font-size-sm);
+  opacity: 0.9;
+}
+
+.compression-toast .btn-secondary {
+  background-color: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: white;
+}
+
+.compression-toast .btn-secondary:hover {
+  background-color: rgba(255, 255, 255, 0.28);
+}

--- a/src/features/compression/CompressionCompletionToast.tsx
+++ b/src/features/compression/CompressionCompletionToast.tsx
@@ -1,0 +1,35 @@
+import { Button } from "../../shared/components";
+import { formatBytes } from "./formatBytes";
+import type { BatchCompletionSummary } from "./useCompressionBatch";
+import "./CompressionCompletionToast.css";
+
+interface CompressionCompletionToastProps {
+  summary: BatchCompletionSummary;
+  onDismiss: () => void;
+}
+
+export default function CompressionCompletionToast({
+  summary,
+  onDismiss,
+}: CompressionCompletionToastProps) {
+  const headline = summary.cancelled
+    ? "Compression cancelled"
+    : "Compression complete";
+
+  return (
+    <div className="compression-toast" role="status">
+      <div className="compression-toast-text">
+        <strong>{headline}</strong>
+        <span>
+          Compressed {summary.compressed} of {summary.total} files
+          {summary.skipped > 0 && ` · skipped ${summary.skipped}`}
+          {" · freed "}
+          {formatBytes(summary.bytesFreed)}
+        </span>
+      </div>
+      <Button variant="secondary" onClick={onDismiss}>
+        Dismiss
+      </Button>
+    </div>
+  );
+}

--- a/src/features/compression/CompressionProgressDialog.css
+++ b/src/features/compression/CompressionProgressDialog.css
@@ -1,0 +1,57 @@
+.compression-progress-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.45);
+}
+
+.compression-progress-panel {
+  width: min(520px, 92vw);
+  padding: var(--space-2xl);
+  background-color: var(--color-bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.compression-progress-title {
+  margin: 0;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.compression-progress-counter {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+}
+
+.compression-progress-current {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.compression-progress-current span {
+  font-family: var(--font-family-mono);
+  color: var(--color-text-primary);
+}
+
+.compression-progress-freed {
+  margin: 0;
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+}
+
+.compression-progress-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-md);
+  margin-top: var(--space-md);
+}

--- a/src/features/compression/CompressionProgressDialog.tsx
+++ b/src/features/compression/CompressionProgressDialog.tsx
@@ -1,0 +1,66 @@
+import { Button, ProgressBar } from "../../shared/components";
+import { BatchProgress } from "./compressionTypes";
+import { formatBytes } from "./formatBytes";
+import "./CompressionProgressDialog.css";
+
+interface CompressionProgressDialogProps {
+  progress: BatchProgress;
+  onRunInBackground: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Modal-ish overlay shown while a batch run is in flight. The "Run in
+ * background" button hides the overlay without stopping the worker — the
+ * batch keeps running and the user gets the completion toast when it lands.
+ */
+export default function CompressionProgressDialog({
+  progress,
+  onRunInBackground,
+  onCancel,
+}: CompressionProgressDialogProps) {
+  if (progress.status === "idle") return null;
+
+  const percent =
+    progress.total === 0
+      ? 0
+      : Math.min(100, Math.round((progress.currentIndex / progress.total) * 100));
+
+  return (
+    <div className="compression-progress-overlay" role="dialog" aria-modal="true">
+      <div className="compression-progress-panel">
+        <h3 className="compression-progress-title">
+          Compressing Audio Files
+        </h3>
+
+        <ProgressBar percent={percent} height={8} />
+        <p className="compression-progress-counter">
+          {progress.currentIndex} of {progress.total}
+        </p>
+
+        {progress.currentFile && (
+          <p className="compression-progress-current">
+            Current: <span>{progress.currentFile}</span>
+          </p>
+        )}
+
+        <p className="compression-progress-freed">
+          Freed so far: <strong>{formatBytes(progress.bytesFreed)}</strong>
+        </p>
+
+        <div className="compression-progress-actions">
+          <Button
+            variant="secondary"
+            onClick={onCancel}
+            disabled={progress.status === "cancelling"}
+          >
+            {progress.status === "cancelling" ? "Cancelling…" : "Cancel"}
+          </Button>
+          <Button variant="primary" onClick={onRunInBackground}>
+            Run in Background
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/compression/CompressionService.ts
+++ b/src/features/compression/CompressionService.ts
@@ -1,0 +1,118 @@
+import { wrapTauriInvoke } from "../../api/services/tauriInvokeWrapper";
+import {
+  BatchProgress,
+  IDLE_BATCH_PROGRESS,
+  StorageStats,
+} from "./compressionTypes";
+
+interface BackendBatchProgress {
+  status: BatchProgress["status"];
+  total: number;
+  currentIndex: number;
+  currentFile: string | null;
+  bytesFreed: number;
+  skipped: number;
+  compressed: number;
+}
+
+/** Options for kicking off a manual batch run. */
+export interface StartBatchOptions {
+  /**
+   * Bypass the configured `compressOldRecordingsOlderThanDays` threshold and
+   * treat every uncompressed WAV as eligible. Used by the "Compress all WAV
+   * files" button. When omitted, the worker reads the threshold from config —
+   * which is how the automatic startup sweep operates.
+   */
+  ignoreThreshold?: boolean;
+}
+
+export interface ICompressionService {
+  /** Trigger the batch compression worker. Errors if a run is already in flight. */
+  startBatch(options?: StartBatchOptions): Promise<void>;
+  /** Ask an in-flight batch to stop after the current file. */
+  cancelBatch(): Promise<void>;
+  /** Read the current batch progress snapshot. Used as a fallback if event listeners attach late. */
+  getProgress(): Promise<BatchProgress>;
+  /** Snapshot of how much disk space recordings occupy. */
+  getStorageStats(): Promise<StorageStats>;
+}
+
+export class TauriCompressionService implements ICompressionService {
+  async startBatch(options?: StartBatchOptions): Promise<void> {
+    // `ignoreThreshold` maps to `thresholdDaysOverride=0` on the backend —
+    // anything aged > 0 days (i.e., everything) becomes eligible.
+    const thresholdDaysOverride = options?.ignoreThreshold ? 0 : null;
+    return wrapTauriInvoke<void>(
+      "start_compression_batch",
+      { thresholdDaysOverride },
+      "Failed to start compression batch",
+      "COMPRESSION_BATCH_START_FAILED"
+    );
+  }
+
+  async cancelBatch(): Promise<void> {
+    return wrapTauriInvoke<void>(
+      "cancel_compression_batch",
+      undefined,
+      "Failed to cancel compression batch",
+      "COMPRESSION_BATCH_CANCEL_FAILED"
+    );
+  }
+
+  async getProgress(): Promise<BatchProgress> {
+    const raw = await wrapTauriInvoke<BackendBatchProgress>(
+      "get_compression_progress",
+      undefined,
+      "Failed to read compression progress",
+      "COMPRESSION_PROGRESS_FAILED"
+    );
+    return raw;
+  }
+
+  async getStorageStats(): Promise<StorageStats> {
+    return wrapTauriInvoke<StorageStats>(
+      "get_storage_stats",
+      undefined,
+      "Failed to read storage stats",
+      "STORAGE_STATS_FAILED"
+    );
+  }
+}
+
+/**
+ * Mock for tests — keeps a tiny in-memory state machine so progress events
+ * can be simulated without spawning real workers.
+ */
+export class MockCompressionService implements ICompressionService {
+  private progress: BatchProgress = { ...IDLE_BATCH_PROGRESS };
+  private storage: StorageStats = {
+    wavCount: 12,
+    wavBytes: 200 * 1024 * 1024,
+    m4aCount: 0,
+    m4aBytes: 0,
+    estimatedSavingsBytes: 180 * 1024 * 1024,
+  };
+
+  async startBatch(_options?: StartBatchOptions): Promise<void> {
+    this.progress = {
+      ...IDLE_BATCH_PROGRESS,
+      status: "running",
+      total: this.storage.wavCount,
+    };
+  }
+  async cancelBatch(): Promise<void> {
+    this.progress = { ...this.progress, status: "cancelling" };
+  }
+  async getProgress(): Promise<BatchProgress> {
+    return { ...this.progress };
+  }
+  async getStorageStats(): Promise<StorageStats> {
+    return { ...this.storage };
+  }
+  __setStorage(stats: StorageStats) {
+    this.storage = { ...stats };
+  }
+  __setProgress(progress: BatchProgress) {
+    this.progress = { ...progress };
+  }
+}

--- a/src/features/compression/CompressionStorageSummary.css
+++ b/src/features/compression/CompressionStorageSummary.css
@@ -1,0 +1,25 @@
+.compression-storage-summary {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.compression-storage-summary strong {
+  display: block;
+  margin-bottom: var(--space-xs);
+  color: var(--color-text-primary);
+}
+
+.compression-storage-summary ul {
+  margin: 0;
+  padding-left: var(--space-lg);
+}
+
+.compression-storage-summary li {
+  line-height: var(--line-height-normal);
+}
+
+.compression-storage-summary-loading {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/src/features/compression/CompressionStorageSummary.tsx
+++ b/src/features/compression/CompressionStorageSummary.tsx
@@ -1,0 +1,41 @@
+import { StorageStats } from "./compressionTypes";
+import { formatBytes } from "./formatBytes";
+import "./CompressionStorageSummary.css";
+
+interface CompressionStorageSummaryProps {
+  stats: StorageStats | null;
+}
+
+export default function CompressionStorageSummary({
+  stats,
+}: CompressionStorageSummaryProps) {
+  if (!stats) {
+    return (
+      <p className="compression-storage-summary-loading">
+        Counting recordings…
+      </p>
+    );
+  }
+
+  return (
+    <div className="compression-storage-summary">
+      <strong>Current storage:</strong>
+      <ul>
+        <li>
+          {stats.wavCount} WAV file{stats.wavCount === 1 ? "" : "s"} (
+          {formatBytes(stats.wavBytes)})
+        </li>
+        <li>
+          {stats.m4aCount} compressed file{stats.m4aCount === 1 ? "" : "s"}
+          {stats.m4aCount > 0 && ` (${formatBytes(stats.m4aBytes)})`}
+        </li>
+        {stats.wavBytes > 0 && (
+          <li>
+            Estimated savings if compressed: ~
+            {formatBytes(stats.estimatedSavingsBytes)}
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/compression/compressNowDisabledReason.test.ts
+++ b/src/features/compression/compressNowDisabledReason.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { resolveCompressNowDisabledReason } from "./compressNowDisabledReason";
+
+describe("resolveCompressNowDisabledReason", () => {
+  it("returns the FFmpeg prerequisite message when ffmpeg is not configured", () => {
+    // Even if a batch were somehow already running, the missing prerequisite
+    // takes precedence — the user's first problem to solve is configuration.
+    expect(
+      resolveCompressNowDisabledReason({
+        ffmpegConfigured: false,
+        isRunning: true,
+        isStarting: true,
+      })
+    ).toBe("Configure FFmpeg path first");
+  });
+
+  it("returns the already-running message when a batch is running", () => {
+    expect(
+      resolveCompressNowDisabledReason({
+        ffmpegConfigured: true,
+        isRunning: true,
+        isStarting: false,
+      })
+    ).toBe("A compression batch is already running");
+  });
+
+  it("returns the spinning-up message when start is in flight", () => {
+    expect(
+      resolveCompressNowDisabledReason({
+        ffmpegConfigured: true,
+        isRunning: false,
+        isStarting: true,
+      })
+    ).toBe("Starting…");
+  });
+
+  it("returns undefined (enabled) when everything is ready", () => {
+    expect(
+      resolveCompressNowDisabledReason({
+        ffmpegConfigured: true,
+        isRunning: false,
+        isStarting: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it("prefers the running message over the starting message when both are true", () => {
+    // `isStarting` flips true at the moment we invoke the service, and stays
+    // that way until the service call resolves. `isRunning` flips true once
+    // the backend has actually started a batch. There's a tiny overlap where
+    // both can be true — the "already running" message is the more accurate
+    // one to show.
+    expect(
+      resolveCompressNowDisabledReason({
+        ffmpegConfigured: true,
+        isRunning: true,
+        isStarting: true,
+      })
+    ).toBe("A compression batch is already running");
+  });
+});

--- a/src/features/compression/compressNowDisabledReason.ts
+++ b/src/features/compression/compressNowDisabledReason.ts
@@ -1,0 +1,30 @@
+/**
+ * Decide whether the "Compress now" action should be enabled, and if not, why.
+ *
+ * Encapsulates the precedence rules:
+ *   1. FFmpeg must be configured at all.
+ *   2. Another batch must not already be running.
+ *   3. We must not be mid-spin-up of a new batch.
+ *
+ * Returning `undefined` means the action is enabled. A string return doubles
+ * as both the disabled tooltip and the inline hint message.
+ *
+ * Kept as a pure function (no React, no hooks) so the precedence ordering is
+ * testable in isolation and never drifts inside a `.tsx` ternary.
+ */
+export function resolveCompressNowDisabledReason(input: {
+  ffmpegConfigured: boolean;
+  isRunning: boolean;
+  isStarting: boolean;
+}): string | undefined {
+  if (!input.ffmpegConfigured) {
+    return "Configure FFmpeg path first";
+  }
+  if (input.isRunning) {
+    return "A compression batch is already running";
+  }
+  if (input.isStarting) {
+    return "Starting…";
+  }
+  return undefined;
+}

--- a/src/features/compression/compressionTypes.ts
+++ b/src/features/compression/compressionTypes.ts
@@ -1,0 +1,34 @@
+/**
+ * Frontend mirror types for the batch compression subsystem. Matches the
+ * shapes serialized by `src-tauri/src/recording/compression/`.
+ */
+
+export type BatchStatus = "idle" | "running" | "cancelling";
+
+export interface BatchProgress {
+  status: BatchStatus;
+  total: number;
+  currentIndex: number;
+  currentFile: string | null;
+  bytesFreed: number;
+  skipped: number;
+  compressed: number;
+}
+
+export interface StorageStats {
+  wavCount: number;
+  wavBytes: number;
+  m4aCount: number;
+  m4aBytes: number;
+  estimatedSavingsBytes: number;
+}
+
+export const IDLE_BATCH_PROGRESS: BatchProgress = {
+  status: "idle",
+  total: 0,
+  currentIndex: 0,
+  currentFile: null,
+  bytesFreed: 0,
+  skipped: 0,
+  compressed: 0,
+};

--- a/src/features/compression/formatBytes.test.ts
+++ b/src/features/compression/formatBytes.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes } from "./formatBytes";
+
+describe("formatBytes", () => {
+  it("returns bytes for small counts", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("flips to KB at 1024", () => {
+    expect(formatBytes(1024)).toBe("1.00 KB");
+    expect(formatBytes(1536)).toBe("1.50 KB");
+  });
+
+  it("flips to MB at 1024^2", () => {
+    expect(formatBytes(1024 * 1024)).toBe("1.00 MB");
+    expect(formatBytes(1024 * 1024 * 23.4)).toMatch(/^23\.\d+ MB$/);
+  });
+
+  it("flips to GB at 1024^3", () => {
+    expect(formatBytes(1024 ** 3)).toBe("1.00 GB");
+    expect(formatBytes(45.2 * 1024 ** 3)).toMatch(/^45\.\d+ GB$/);
+  });
+
+  it("uses zero decimals for large round numbers", () => {
+    expect(formatBytes(150 * 1024 ** 3)).toBe("150 GB");
+  });
+
+  it("guards against non-finite or negative input", () => {
+    expect(formatBytes(NaN)).toBe("0 B");
+    expect(formatBytes(-1)).toBe("0 B");
+    expect(formatBytes(Infinity)).toBe("0 B");
+  });
+});

--- a/src/features/compression/formatBytes.ts
+++ b/src/features/compression/formatBytes.ts
@@ -1,0 +1,23 @@
+/**
+ * Format a byte count as a human-readable string ("1.2 GB", "23 MB", "512 KB").
+ *
+ * Uses 1024-based units (GB really meaning GiB) to match Windows Explorer's
+ * convention so the numbers we display line up with what users see when
+ * checking disk space themselves.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  const precision = value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(precision)} ${units[unitIndex]}`;
+}

--- a/src/features/compression/useCompressionBatch.ts
+++ b/src/features/compression/useCompressionBatch.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  BatchProgress,
+  IDLE_BATCH_PROGRESS,
+  StorageStats,
+} from "./compressionTypes";
+import {
+  COMPRESSION_BATCH_COMPLETE,
+  COMPRESSION_BATCH_PROGRESS,
+  CompressionBatchCompletePayload,
+  CompressionBatchProgressPayload,
+  useApi,
+} from "../../api";
+import { resolveCompressNowDisabledReason } from "./compressNowDisabledReason";
+import { logger } from "../../shared/utils/logger";
+
+export interface BatchCompletionSummary {
+  total: number;
+  compressed: number;
+  skipped: number;
+  bytesFreed: number;
+  cancelled: boolean;
+}
+
+export interface CompressionBatchHandle {
+  progress: BatchProgress;
+  storage: StorageStats | null;
+  lastCompletion: BatchCompletionSummary | null;
+  isStarting: boolean;
+  isRunning: boolean;
+  errorMessage: string | null;
+  start: (options?: { ignoreThreshold?: boolean }) => Promise<void>;
+  cancel: () => Promise<void>;
+  refreshStorage: () => Promise<void>;
+  dismissCompletion: () => void;
+  /**
+   * Returns a user-facing reason the "Compress now" action is unavailable, or
+   * `undefined` when the action is enabled. Centralises the precedence rules
+   * (missing prerequisite → already-running → still-spinning-up) so they live
+   * in one place instead of being inlined in a component.
+   */
+  getCompressNowDisabledReason: (
+    ffmpegConfigured: boolean
+  ) => string | undefined;
+}
+
+/**
+ * React hook that wires the compression service to a small state machine.
+ *
+ * Owns:
+ * - subscriptions to the `compression-batch-progress` / `-complete` events
+ * - the user-facing progress + storage snapshot
+ * - the "last completion summary" used to show the completion toast
+ */
+export function useCompressionBatch(): CompressionBatchHandle {
+  const { compressionService } = useApi();
+  const [progress, setProgress] = useState<BatchProgress>(IDLE_BATCH_PROGRESS);
+  const [storage, setStorage] = useState<StorageStats | null>(null);
+  const [lastCompletion, setLastCompletion] =
+    useState<BatchCompletionSummary | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Pull the initial snapshot once on mount so the panel renders accurate
+  // numbers immediately rather than after the first event.
+  useEffect(() => {
+    void compressionService
+      .getProgress()
+      .then(setProgress)
+      .catch((e) => logger.error("getProgress failed", e));
+    void compressionService
+      .getStorageStats()
+      .then(setStorage)
+      .catch((e) => logger.error("getStorageStats failed", e));
+  }, [compressionService]);
+
+  // Live event subscriptions
+  useEffect(() => {
+    const unlistenPromises: Promise<() => void>[] = [];
+
+    unlistenPromises.push(
+      listen<CompressionBatchProgressPayload>(
+        COMPRESSION_BATCH_PROGRESS,
+        (event) => {
+          setProgress((prev) => ({
+            ...prev,
+            status: "running",
+            total: event.payload.total,
+            currentIndex: event.payload.currentIndex,
+            currentFile: event.payload.currentFile,
+            bytesFreed: event.payload.bytesFreed,
+          }));
+        }
+      )
+    );
+
+    unlistenPromises.push(
+      listen<CompressionBatchCompletePayload>(
+        COMPRESSION_BATCH_COMPLETE,
+        (event) => {
+          setProgress({ ...IDLE_BATCH_PROGRESS });
+          // Only surface a completion toast when the run actually did
+          // something — otherwise startup sweeps that find nothing eligible
+          // would noisily report "successfully did nothing." A cancellation
+          // is still worth confirming because the user explicitly asked for it.
+          if (event.payload.compressed > 0 || event.payload.cancelled) {
+            setLastCompletion({
+              total: event.payload.total,
+              compressed: event.payload.compressed,
+              skipped: event.payload.skipped,
+              bytesFreed: event.payload.bytesFreed,
+              cancelled: event.payload.cancelled,
+            });
+          }
+          // Storage stats will have changed; refresh.
+          void compressionService
+            .getStorageStats()
+            .then(setStorage)
+            .catch((e) => logger.error("getStorageStats failed", e));
+        }
+      )
+    );
+
+    return () => {
+      unlistenPromises.forEach((p) =>
+        p.then((unlisten) => unlisten()).catch(() => undefined)
+      );
+    };
+  }, [compressionService]);
+
+  const start = useCallback(
+    async (options?: { ignoreThreshold?: boolean }) => {
+      setErrorMessage(null);
+      setLastCompletion(null);
+      setIsStarting(true);
+      try {
+        await compressionService.startBatch(options);
+        const fresh = await compressionService.getProgress();
+        setProgress(fresh);
+      } catch (error) {
+        const msg =
+          error instanceof Error ? error.message : "Failed to start compression";
+        setErrorMessage(msg);
+        logger.error("startBatch failed", error);
+      } finally {
+        setIsStarting(false);
+      }
+    },
+    [compressionService]
+  );
+
+  const cancel = useCallback(async () => {
+    try {
+      await compressionService.cancelBatch();
+    } catch (error) {
+      logger.error("cancelBatch failed", error);
+    }
+  }, [compressionService]);
+
+  const refreshStorage = useCallback(async () => {
+    try {
+      const stats = await compressionService.getStorageStats();
+      setStorage(stats);
+    } catch (error) {
+      logger.error("refreshStorage failed", error);
+    }
+  }, [compressionService]);
+
+  const dismissCompletion = useCallback(() => setLastCompletion(null), []);
+
+  const isRunning = progress.status !== "idle";
+
+  const getCompressNowDisabledReason = useCallback(
+    (ffmpegConfigured: boolean) =>
+      resolveCompressNowDisabledReason({
+        ffmpegConfigured,
+        isRunning,
+        isStarting,
+      }),
+    [isRunning, isStarting]
+  );
+
+  return {
+    progress,
+    storage,
+    lastCompletion,
+    isStarting,
+    isRunning,
+    errorMessage,
+    start,
+    cancel,
+    refreshStorage,
+    dismissCompletion,
+    getCompressNowDisabledReason,
+  };
+}

--- a/src/features/recording/useAudioLevels.test.ts
+++ b/src/features/recording/useAudioLevels.test.ts
@@ -33,6 +33,8 @@ describe("useAudioLevels", () => {
           transcriptService: undefined as any,
           clipboardService: undefined as any,
           transcriptionStatsService: {} as any,
+          settingsService: {} as any,
+          compressionService: {} as any,
         },
       }
     );

--- a/src/features/sessions/useTranscriptViewer.test.ts
+++ b/src/features/sessions/useTranscriptViewer.test.ts
@@ -140,6 +140,8 @@ describe('useTranscriptViewer', () => {
           sessionService: mockSessionService as any,
           recordingService: mockRecordingService as any,
           transcriptionStatsService: {} as any,
+          settingsService: {} as any,
+          compressionService: {} as any,
         },
       }
     );

--- a/src/features/settings/PathPickerField.css
+++ b/src/features/settings/PathPickerField.css
@@ -1,0 +1,62 @@
+.settings-path-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-lg);
+}
+
+.settings-path-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+}
+
+.settings-path-row {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: stretch;
+}
+
+.settings-path-input {
+  flex: 1;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+}
+
+.settings-path-input:focus {
+  border-color: var(--color-primary-border);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
+}
+
+.settings-path-status {
+  min-height: 16px;
+  font-size: var(--font-size-xs);
+}
+
+.settings-path-status .status-message.status-success {
+  color: var(--color-success);
+}
+
+.settings-path-status .status-message.status-error {
+  color: var(--color-danger);
+}
+
+.settings-path-status .status-message.status-checking {
+  color: var(--color-warning);
+}
+
+.settings-path-status .status-message.status-idle {
+  color: var(--color-text-muted);
+}
+
+.settings-path-help {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/src/features/settings/PathPickerField.tsx
+++ b/src/features/settings/PathPickerField.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from "react";
+import { Button } from "../../shared/components";
+import { useFilePicker, FilePickerOptions } from "./useFilePicker";
+import { PathKind } from "./appConfig";
+import type { ValidationStatus } from "./useSettingsForm";
+import "./PathPickerField.css";
+
+interface PathPickerFieldProps {
+  label: string;
+  value: string;
+  pickerOptions: FilePickerOptions;
+  kind: PathKind;
+  validation: ValidationStatus | undefined;
+  errorOverride?: string;
+  onChange: (next: string) => void;
+  onValidate: () => void;
+  helpText?: string;
+}
+
+/**
+ * Label + path input + Browse button + validation status icon.
+ *
+ * Auto-fires validation on mount (when there's already a value) and after the
+ * user changes the path via picker. Free-text edits don't auto-validate to
+ * avoid hammering the filesystem on every keystroke — the user can blur the
+ * field (handled here on `onBlur`) to recheck.
+ */
+export default function PathPickerField({
+  label,
+  value,
+  pickerOptions,
+  kind: _kind,
+  validation,
+  errorOverride,
+  onChange,
+  onValidate,
+  helpText,
+}: PathPickerFieldProps) {
+  const { pickFile } = useFilePicker();
+
+  useEffect(() => {
+    if (value.trim() !== "") {
+      onValidate();
+    }
+    // Intentionally only on first mount per field — subsequent changes flow
+    // through onBlur / onBrowse, not value churn.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleBrowse = async () => {
+    const picked = await pickFile(pickerOptions);
+    if (picked !== null) {
+      onChange(picked);
+      // Defer validation to the next event loop so the new value is in flight
+      // when the parent re-renders.
+      queueMicrotask(onValidate);
+    }
+  };
+
+  const statusIcon = renderStatusIcon(validation, errorOverride);
+
+  return (
+    <div className="settings-path-field">
+      <label className="settings-path-label">{label}</label>
+      <div className="settings-path-row">
+        <input
+          type="text"
+          className="settings-path-input"
+          value={value}
+          spellCheck={false}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onValidate}
+          placeholder="Click Browse… or paste a path"
+        />
+        <Button variant="secondary" onClick={handleBrowse}>
+          Browse…
+        </Button>
+      </div>
+      <div className="settings-path-status">{statusIcon}</div>
+      {helpText && <div className="settings-path-help">{helpText}</div>}
+    </div>
+  );
+}
+
+function renderStatusIcon(
+  validation: ValidationStatus | undefined,
+  errorOverride: string | undefined
+) {
+  if (errorOverride) {
+    return <span className="status-message status-error">⚠ {errorOverride}</span>;
+  }
+  if (!validation || validation.state === "idle") {
+    return <span className="status-message status-idle">Not validated</span>;
+  }
+  if (validation.state === "checking") {
+    return <span className="status-message status-checking">Checking…</span>;
+  }
+  const r = validation.result;
+  if (r.exists && r.kind_ok) {
+    return <span className="status-message status-success">✓ {r.message}</span>;
+  }
+  return <span className="status-message status-error">⚠ {r.message}</span>;
+}

--- a/src/features/settings/SettingsPanel.css
+++ b/src/features/settings/SettingsPanel.css
@@ -1,0 +1,134 @@
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.settings-backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  animation: fadeIn 0.15s ease-out;
+}
+
+.settings-panel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: min(720px, 92vw);
+  max-height: 88vh;
+  background-color: var(--color-bg-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  animation: settingsPanelIn 0.18s ease-out;
+}
+
+@keyframes settingsPanelIn {
+  from {
+    transform: translateY(10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.settings-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-xl) var(--space-2xl);
+  border-bottom: 1px solid var(--color-border);
+  background-color: var(--color-bg-secondary);
+}
+
+.settings-panel-title {
+  margin: 0;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.settings-close-button {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  font-size: 24px;
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  border-radius: var(--radius-md);
+}
+
+.settings-close-button:hover {
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+.settings-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-md) var(--space-2xl);
+}
+
+.settings-loading,
+.settings-error {
+  padding: var(--space-2xl);
+  text-align: center;
+  color: var(--color-text-tertiary);
+}
+
+.settings-error {
+  color: var(--color-danger);
+}
+
+.settings-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-lg) var(--space-2xl);
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg-secondary);
+}
+
+.settings-save-error {
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+}
+
+.settings-panel-buttons {
+  display: flex;
+  gap: var(--space-md);
+  margin-left: auto;
+}
+
+.settings-discard-prompt {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-lg);
+  background-color: rgba(255, 255, 255, 0.95);
+  padding: var(--space-3xl);
+  text-align: center;
+}
+
+.settings-discard-prompt p {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
+}
+
+.settings-discard-actions {
+  display: flex;
+  gap: var(--space-md);
+}

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+import { Button } from "../../shared/components";
+import { useSettingsForm } from "./useSettingsForm";
+import TranscriptionSettingsSection from "./sections/TranscriptionSettingsSection";
+import CompressionSettingsSection from "./sections/CompressionSettingsSection";
+import "./SettingsPanel.css";
+
+interface SettingsPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Optional slot for Phase D's compression batch UI (storage stats + Compress Now). */
+  renderCompressionExtras?: (
+    form: ReturnType<typeof useSettingsForm>
+  ) => {
+    onCompressNow?: () => void;
+    compressNowDisabledReason?: string;
+    storageSummary?: React.ReactNode;
+  };
+}
+
+/**
+ * Settings panel modal — host for all in-app configuration sections.
+ *
+ * The panel itself is dumb chrome: it owns the open/close lifecycle and the
+ * Save/Cancel bar. Each settings *section* is a self-contained component that
+ * subscribes to the shared `useSettingsForm` handle. To add a new section,
+ * drop a new `<*SettingsSection form={form} />` inside `.settings-panel-body`.
+ */
+export default function SettingsPanel({
+  isOpen,
+  onClose,
+  renderCompressionExtras,
+}: SettingsPanelProps) {
+  const form = useSettingsForm();
+  const [pendingDiscard, setPendingDiscard] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleRequestClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, form.isDirty]);
+
+  if (!isOpen) return null;
+
+  const handleRequestClose = () => {
+    if (form.isDirty) {
+      setPendingDiscard(true);
+      return;
+    }
+    onClose();
+  };
+
+  const handleDiscardConfirm = () => {
+    form.cancel();
+    setPendingDiscard(false);
+    onClose();
+  };
+
+  const handleSave = async () => {
+    const outcome = await form.save();
+    if (outcome.ok) {
+      onClose();
+    }
+  };
+
+  const extras = renderCompressionExtras?.(form) ?? {};
+
+  return (
+    <div className="settings-overlay" role="dialog" aria-modal="true">
+      <div
+        className="settings-backdrop"
+        onClick={handleRequestClose}
+        aria-hidden="true"
+      />
+      <div className="settings-panel">
+        <header className="settings-panel-header">
+          <h2 className="settings-panel-title">Settings</h2>
+          <button
+            type="button"
+            className="settings-close-button"
+            onClick={handleRequestClose}
+            aria-label="Close settings"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="settings-panel-body">
+          {form.isLoading ? (
+            <p className="settings-loading">Loading settings…</p>
+          ) : form.loadError ? (
+            <p className="settings-error">⚠ {form.loadError}</p>
+          ) : (
+            <>
+              <TranscriptionSettingsSection form={form} />
+              <CompressionSettingsSection
+                form={form}
+                onCompressNow={extras.onCompressNow}
+                compressNowDisabledReason={extras.compressNowDisabledReason}
+                storageSummary={extras.storageSummary}
+              />
+            </>
+          )}
+        </div>
+
+        <footer className="settings-panel-footer">
+          {form.saveError && (
+            <span className="settings-save-error">⚠ {form.saveError}</span>
+          )}
+          <div className="settings-panel-buttons">
+            <Button
+              variant="secondary"
+              onClick={handleRequestClose}
+              disabled={form.isSaving}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleSave}
+              disabled={!form.isDirty || !form.isValid || form.isSaving}
+            >
+              {form.isSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </footer>
+
+        {pendingDiscard && (
+          <div className="settings-discard-prompt" role="alertdialog">
+            <p>You have unsaved changes. Discard them?</p>
+            <div className="settings-discard-actions">
+              <Button
+                variant="secondary"
+                onClick={() => setPendingDiscard(false)}
+              >
+                Keep editing
+              </Button>
+              <Button variant="danger" onClick={handleDiscardConfirm}>
+                Discard
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/settings/SettingsService.test.ts
+++ b/src/features/settings/SettingsService.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TauriSettingsService, MockSettingsService } from "./SettingsService";
+import { DEFAULT_APP_CONFIG } from "./appConfig";
+import { ApiError } from "../../api";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+describe("TauriSettingsService", () => {
+  let service: TauriSettingsService;
+  let mockInvoke: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    service = new TauriSettingsService();
+    const { invoke } = await import("@tauri-apps/api/core");
+    mockInvoke = invoke as ReturnType<typeof vi.fn>;
+    vi.clearAllMocks();
+  });
+
+  describe("loadConfig", () => {
+    it("returns merged defaults when backend returns partial data", async () => {
+      mockInvoke.mockResolvedValue({
+        whisperPath: "/bin/whisper",
+        modelPath: "/m/base.bin",
+      });
+      const config = await service.loadConfig();
+      expect(config.whisperPath).toBe("/bin/whisper");
+      expect(config.ffmpegPath).toBe("");
+      expect(config.audioCompression.compressOldRecordingsOlderThanDays).toBe(7);
+    });
+
+    it("returns defaults when backend returns nothing", async () => {
+      mockInvoke.mockResolvedValue(null);
+      const config = await service.loadConfig();
+      expect(config).toEqual(DEFAULT_APP_CONFIG);
+    });
+
+    it("wraps backend errors in ApiError", async () => {
+      mockInvoke.mockRejectedValue(new Error("disk read failure"));
+      await expect(service.loadConfig()).rejects.toThrow(ApiError);
+      await expect(service.loadConfig()).rejects.toThrow("Failed to load settings");
+    });
+  });
+
+  describe("saveConfig", () => {
+    it("forwards the config in `config` named arg", async () => {
+      mockInvoke.mockResolvedValue(undefined);
+      await service.saveConfig(DEFAULT_APP_CONFIG);
+      expect(mockInvoke).toHaveBeenCalledWith("save_config", {
+        config: DEFAULT_APP_CONFIG,
+      });
+    });
+
+    it("wraps save errors", async () => {
+      mockInvoke.mockRejectedValue(new Error("permission denied"));
+      await expect(service.saveConfig(DEFAULT_APP_CONFIG)).rejects.toThrow(
+        "Failed to save settings"
+      );
+    });
+  });
+
+  describe("validatePath", () => {
+    it("forwards path and kind", async () => {
+      mockInvoke.mockResolvedValue({
+        exists: true,
+        kind_ok: true,
+        version: "6.1",
+        message: "FFmpeg detected (6.1)",
+      });
+      const v = await service.validatePath("/bin/ffmpeg", "ffmpeg");
+      expect(mockInvoke).toHaveBeenCalledWith("validate_config_path", {
+        path: "/bin/ffmpeg",
+        kind: "ffmpeg",
+      });
+      expect(v.version).toBe("6.1");
+    });
+  });
+});
+
+describe("MockSettingsService", () => {
+  it("persists across loadConfig / saveConfig calls", async () => {
+    const svc = new MockSettingsService();
+    const updated = {
+      ...DEFAULT_APP_CONFIG,
+      whisperPath: "/mock/whisper",
+      ffmpegPath: "/mock/ffmpeg",
+    };
+    await svc.saveConfig(updated);
+    const loaded = await svc.loadConfig();
+    expect(loaded.whisperPath).toBe("/mock/whisper");
+    expect(loaded.ffmpegPath).toBe("/mock/ffmpeg");
+  });
+
+  it("rejects empty paths in validatePath", async () => {
+    const svc = new MockSettingsService();
+    const v = await svc.validatePath("", "executable");
+    expect(v.exists).toBe(false);
+  });
+
+  it("simulates ffmpeg version detection", async () => {
+    const svc = new MockSettingsService();
+    const v = await svc.validatePath("/some/ffmpeg", "ffmpeg");
+    expect(v.version).toBe("mock-6.0");
+  });
+});

--- a/src/features/settings/SettingsService.ts
+++ b/src/features/settings/SettingsService.ts
@@ -1,0 +1,97 @@
+import { wrapTauriInvoke } from "../../api/services/tauriInvokeWrapper";
+import {
+  AppConfig,
+  DEFAULT_APP_CONFIG,
+  PathKind,
+  PathValidation,
+} from "./appConfig";
+import { mergeConfigDefaults } from "./mergeConfigDefaults";
+
+/**
+ * Settings persistence service — owns the round-trip with `config.json`
+ * via the Tauri layer.
+ */
+export interface ISettingsService {
+  /** Load current config from disk; returns defaults if not yet saved. */
+  loadConfig(): Promise<AppConfig>;
+  /** Save the provided config to disk, atomically. */
+  saveConfig(config: AppConfig): Promise<void>;
+  /** Probe a single path for validity per the given kind. */
+  validatePath(path: string, kind: PathKind): Promise<PathValidation>;
+}
+
+export class TauriSettingsService implements ISettingsService {
+  async loadConfig(): Promise<AppConfig> {
+    const raw = await wrapTauriInvoke<Partial<AppConfig> | null>(
+      "load_config",
+      undefined,
+      "Failed to load settings",
+      "SETTINGS_LOAD_FAILED"
+    );
+    return mergeConfigDefaults(raw);
+  }
+
+  async saveConfig(config: AppConfig): Promise<void> {
+    return wrapTauriInvoke<void>(
+      "save_config",
+      { config },
+      "Failed to save settings",
+      "SETTINGS_SAVE_FAILED"
+    );
+  }
+
+  async validatePath(path: string, kind: PathKind): Promise<PathValidation> {
+    return wrapTauriInvoke<PathValidation>(
+      "validate_config_path",
+      { path, kind },
+      "Failed to validate path",
+      "SETTINGS_VALIDATE_FAILED"
+    );
+  }
+}
+
+/**
+ * Mock for tests and Storybook-style harnesses.
+ */
+export class MockSettingsService implements ISettingsService {
+  private stored: AppConfig = { ...DEFAULT_APP_CONFIG };
+
+  async loadConfig(): Promise<AppConfig> {
+    await new Promise((r) => setTimeout(r, 10));
+    return { ...this.stored };
+  }
+
+  async saveConfig(config: AppConfig): Promise<void> {
+    await new Promise((r) => setTimeout(r, 10));
+    this.stored = { ...config };
+  }
+
+  async validatePath(path: string, kind: PathKind): Promise<PathValidation> {
+    await new Promise((r) => setTimeout(r, 5));
+    if (path.trim() === "") {
+      return {
+        exists: false,
+        kind_ok: false,
+        version: null,
+        message: "Path is empty",
+      };
+    }
+    // Treat any non-empty path as "valid" in the mock, so test setups don't
+    // need to seed a real filesystem.
+    const version = kind === "ffmpeg" ? "mock-6.0" : null;
+    return {
+      exists: true,
+      kind_ok: true,
+      version,
+      message: kind === "ffmpeg" ? "FFmpeg detected (mock-6.0)" : "File found",
+    };
+  }
+
+  // Test helpers
+  __setStored(config: AppConfig) {
+    this.stored = { ...config };
+  }
+  __getStored(): AppConfig {
+    return { ...this.stored };
+  }
+}

--- a/src/features/settings/appConfig.ts
+++ b/src/features/settings/appConfig.ts
@@ -1,0 +1,40 @@
+/**
+ * Application configuration types, defaults, and shared constants — mirrors
+ * `AppConfig` in `src-tauri/src/recording/models.rs`. Fields use camelCase to
+ * match the JSON contract on disk and over the Tauri boundary.
+ */
+export interface AudioCompressionConfig {
+  compressNewRecordings: boolean;
+  compressOldRecordingsEnabled: boolean;
+  compressOldRecordingsOlderThanDays: number;
+}
+
+export interface AppConfig {
+  whisperPath: string;
+  modelPath: string;
+  voiceNotesDir?: string;
+  ffmpegPath: string;
+  audioCompression: AudioCompressionConfig;
+}
+
+export type PathKind = "executable" | "file" | "ffmpeg";
+
+export interface PathValidation {
+  exists: boolean;
+  kind_ok: boolean;
+  version: string | null;
+  message: string;
+}
+
+export const DEFAULT_APP_CONFIG: AppConfig = {
+  whisperPath: "",
+  modelPath: "",
+  ffmpegPath: "",
+  audioCompression: {
+    compressNewRecordings: true,
+    compressOldRecordingsEnabled: false,
+    compressOldRecordingsOlderThanDays: 7,
+  },
+};
+
+export const COMPRESSION_AGE_OPTIONS: readonly number[] = [1, 7, 30];

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,16 @@
+export { default as SettingsPanel } from "./SettingsPanel";
+export { useSettingsPanel } from "./useSettingsPanel";
+export { useSettingsForm } from "./useSettingsForm";
+export type { SettingsFormState, SettingsFormActions } from "./useSettingsForm";
+export {
+  TauriSettingsService,
+  MockSettingsService,
+} from "./SettingsService";
+export type { ISettingsService } from "./SettingsService";
+export type {
+  AppConfig,
+  AudioCompressionConfig,
+  PathKind,
+  PathValidation,
+} from "./appConfig";
+export { DEFAULT_APP_CONFIG, COMPRESSION_AGE_OPTIONS } from "./appConfig";

--- a/src/features/settings/mergeConfigDefaults.test.ts
+++ b/src/features/settings/mergeConfigDefaults.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { mergeConfigDefaults } from "./mergeConfigDefaults";
+import { DEFAULT_APP_CONFIG } from "./appConfig";
+
+describe("mergeConfigDefaults", () => {
+  it("returns a fresh defaults object when given null", () => {
+    const merged = mergeConfigDefaults(null);
+    expect(merged).toEqual(DEFAULT_APP_CONFIG);
+  });
+
+  it("returns a fresh defaults object when given undefined", () => {
+    const merged = mergeConfigDefaults(undefined);
+    expect(merged).toEqual(DEFAULT_APP_CONFIG);
+  });
+
+  it("preserves provided top-level fields and fills the rest", () => {
+    const merged = mergeConfigDefaults({
+      whisperPath: "/bin/whisper",
+      modelPath: "/m/base.bin",
+    });
+
+    expect(merged.whisperPath).toBe("/bin/whisper");
+    expect(merged.modelPath).toBe("/m/base.bin");
+    expect(merged.ffmpegPath).toBe("");
+    expect(merged.audioCompression.compressOldRecordingsOlderThanDays).toBe(7);
+  });
+
+  it("fills missing compression fields when section is partial", () => {
+    const merged = mergeConfigDefaults({
+      audioCompression: {
+        compressNewRecordings: true,
+      } as never,
+    });
+
+    expect(merged.audioCompression.compressNewRecordings).toBe(true);
+    expect(merged.audioCompression.compressOldRecordingsEnabled).toBe(false);
+    expect(merged.audioCompression.compressOldRecordingsOlderThanDays).toBe(7);
+  });
+
+  it("does not mutate the input", () => {
+    const input = { whisperPath: "/x" };
+    const before = JSON.stringify(input);
+    mergeConfigDefaults(input);
+    expect(JSON.stringify(input)).toBe(before);
+  });
+});

--- a/src/features/settings/mergeConfigDefaults.ts
+++ b/src/features/settings/mergeConfigDefaults.ts
@@ -1,0 +1,42 @@
+import {
+  AppConfig,
+  DEFAULT_APP_CONFIG,
+  AudioCompressionConfig,
+} from "./appConfig";
+
+/**
+ * Fill in missing fields on a partial AppConfig coming from disk or the
+ * backend, so the UI can always assume a fully-populated shape.
+ *
+ * Backend `serde(default)` already does this, but a freshly-installed user
+ * has no `config.json` at all and `load_config` returns `AppConfig::default()`
+ * — the merge here also defends against the (rare) case where a hand-edited
+ * JSON file drops a section entirely.
+ */
+export function mergeConfigDefaults(
+  partial: Partial<AppConfig> | null | undefined
+): AppConfig {
+  if (!partial) return { ...DEFAULT_APP_CONFIG };
+
+  const compressionPartial = (partial.audioCompression ?? {}) as Partial<
+    AudioCompressionConfig
+  >;
+
+  return {
+    whisperPath: partial.whisperPath ?? DEFAULT_APP_CONFIG.whisperPath,
+    modelPath: partial.modelPath ?? DEFAULT_APP_CONFIG.modelPath,
+    voiceNotesDir: partial.voiceNotesDir,
+    ffmpegPath: partial.ffmpegPath ?? DEFAULT_APP_CONFIG.ffmpegPath,
+    audioCompression: {
+      compressNewRecordings:
+        compressionPartial.compressNewRecordings ??
+        DEFAULT_APP_CONFIG.audioCompression.compressNewRecordings,
+      compressOldRecordingsEnabled:
+        compressionPartial.compressOldRecordingsEnabled ??
+        DEFAULT_APP_CONFIG.audioCompression.compressOldRecordingsEnabled,
+      compressOldRecordingsOlderThanDays:
+        compressionPartial.compressOldRecordingsOlderThanDays ??
+        DEFAULT_APP_CONFIG.audioCompression.compressOldRecordingsOlderThanDays,
+    },
+  };
+}

--- a/src/features/settings/sections/CompressionSettingsSection.css
+++ b/src/features/settings/sections/CompressionSettingsSection.css
@@ -1,0 +1,67 @@
+.compression-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xs) 0;
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.compression-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.compression-age-row {
+  display: flex;
+  gap: var(--space-xl);
+  padding: var(--space-xs) 0 var(--space-sm) var(--space-2xl);
+}
+
+.compression-age-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.compression-age-option input[type="radio"]:disabled {
+  cursor: not-allowed;
+}
+
+.compression-age-option input[type="radio"]:disabled + span {
+  color: var(--color-text-muted);
+}
+
+.compression-format-note {
+  margin: var(--space-sm) 0 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  font-style: italic;
+}
+
+.compression-storage {
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+}
+
+.compression-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.compression-actions-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-style: italic;
+}

--- a/src/features/settings/sections/CompressionSettingsSection.tsx
+++ b/src/features/settings/sections/CompressionSettingsSection.tsx
@@ -1,0 +1,131 @@
+import SettingsSection from "./SettingsSection";
+import PathPickerField from "../PathPickerField";
+import { COMPRESSION_AGE_OPTIONS } from "../appConfig";
+import type { useSettingsForm } from "../useSettingsForm";
+import "./CompressionSettingsSection.css";
+
+type FormHandle = ReturnType<typeof useSettingsForm>;
+
+interface CompressionSettingsSectionProps {
+  form: FormHandle;
+  onCompressNow?: () => void;
+  compressNowDisabledReason?: string;
+  storageSummary?: React.ReactNode;
+}
+
+/**
+ * Audio Compression section of the Settings panel.
+ *
+ * Toggles + age threshold + (optional) one-time "Compress now" button +
+ * (optional) storage summary slot. The optional props are filled in by
+ * Phase D — Phase A only wires the toggle persistence and FFmpeg path.
+ */
+export default function CompressionSettingsSection({
+  form,
+  onCompressNow,
+  compressNowDisabledReason,
+  storageSummary,
+}: CompressionSettingsSectionProps) {
+  const compression = form.draft.audioCompression;
+
+  return (
+    <SettingsSection
+      title="Audio Compression"
+      description="Convert recordings from uncompressed WAV to compact M4A — about 90% smaller, same audio."
+    >
+      <PathPickerField
+        label="FFmpeg path"
+        value={form.draft.ffmpegPath}
+        kind="ffmpeg"
+        validation={form.pathValidations["ffmpegPath"]}
+        errorOverride={form.fieldErrors.ffmpegPath}
+        pickerOptions={{
+          title: "Locate the FFmpeg binary",
+          filters: [{ name: "Executable", extensions: ["exe", ""] }],
+        }}
+        onChange={(v) => form.setField("ffmpegPath", v)}
+        onValidate={() => form.revalidatePath("ffmpegPath", "ffmpeg")}
+        helpText="Install FFmpeg from ffmpeg.org and point to the binary."
+      />
+
+      <label className="compression-toggle">
+        <input
+          type="checkbox"
+          checked={compression.compressNewRecordings}
+          onChange={(e) =>
+            form.setCompressionField("compressNewRecordings", e.target.checked)
+          }
+        />
+        <span>Compress new recordings after transcription</span>
+      </label>
+
+      <label className="compression-toggle">
+        <input
+          type="checkbox"
+          checked={compression.compressOldRecordingsEnabled}
+          onChange={(e) =>
+            form.setCompressionField(
+              "compressOldRecordingsEnabled",
+              e.target.checked
+            )
+          }
+        />
+        <span>Auto-compress existing recordings older than:</span>
+      </label>
+
+      <div className="compression-age-row">
+        {COMPRESSION_AGE_OPTIONS.map((days) => (
+          <label key={days} className="compression-age-option">
+            <input
+              type="radio"
+              name="compressOldRecordingsOlderThanDays"
+              value={days}
+              checked={
+                compression.compressOldRecordingsOlderThanDays === days
+              }
+              disabled={!compression.compressOldRecordingsEnabled}
+              onChange={() =>
+                form.setCompressionField(
+                  "compressOldRecordingsOlderThanDays",
+                  days
+                )
+              }
+            />
+            <span>{days === 1 ? "1 day" : `${days} days`}</span>
+          </label>
+        ))}
+      </div>
+      <p className="compression-actions-hint">
+        Automatic sweep runs on app startup when this is enabled. The button
+        below ignores the threshold and compresses every uncompressed WAV.
+      </p>
+
+      <p className="compression-format-note">
+        Format: M4A (AAC, ~90% smaller than WAV)
+      </p>
+
+      {storageSummary && (
+        <div className="compression-storage">{storageSummary}</div>
+      )}
+
+      {onCompressNow && (
+        <div className="compression-actions">
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={onCompressNow}
+            disabled={Boolean(compressNowDisabledReason)}
+            title={compressNowDisabledReason}
+          >
+            Compress All WAV Files Now
+          </button>
+          {compressNowDisabledReason && (
+            <span className="compression-actions-hint">
+              {compressNowDisabledReason}
+            </span>
+          )}
+        </div>
+      )}
+    </SettingsSection>
+  );
+}

--- a/src/features/settings/sections/SettingsSection.css
+++ b/src/features/settings/sections/SettingsSection.css
@@ -1,0 +1,36 @@
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-xl) 0;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.settings-section:last-child {
+  border-bottom: none;
+}
+
+.settings-section-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.settings-section-title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.settings-section-description {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+  line-height: var(--line-height-normal);
+}
+
+.settings-section-body {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/features/settings/sections/SettingsSection.tsx
+++ b/src/features/settings/sections/SettingsSection.tsx
@@ -1,0 +1,31 @@
+import "./SettingsSection.css";
+
+interface SettingsSectionProps {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Visual + structural wrapper for a section inside the Settings panel.
+ *
+ * Future settings sections (cleanup, LLM, waveform) slot in by composing this
+ * — they don't need to know about modal chrome.
+ */
+export default function SettingsSection({
+  title,
+  description,
+  children,
+}: SettingsSectionProps) {
+  return (
+    <section className="settings-section">
+      <header className="settings-section-header">
+        <h3 className="settings-section-title">{title}</h3>
+        {description && (
+          <p className="settings-section-description">{description}</p>
+        )}
+      </header>
+      <div className="settings-section-body">{children}</div>
+    </section>
+  );
+}

--- a/src/features/settings/sections/TranscriptionSettingsSection.tsx
+++ b/src/features/settings/sections/TranscriptionSettingsSection.tsx
@@ -1,0 +1,47 @@
+import SettingsSection from "./SettingsSection";
+import PathPickerField from "../PathPickerField";
+import type { useSettingsForm } from "../useSettingsForm";
+
+type FormHandle = ReturnType<typeof useSettingsForm>;
+
+interface TranscriptionSettingsSectionProps {
+  form: FormHandle;
+}
+
+export default function TranscriptionSettingsSection({
+  form,
+}: TranscriptionSettingsSectionProps) {
+  return (
+    <SettingsSection
+      title="Transcription"
+      description="Whisper.cpp binary and model file used to transcribe each recording."
+    >
+      <PathPickerField
+        label="Whisper CLI"
+        value={form.draft.whisperPath}
+        kind="executable"
+        validation={form.pathValidations["whisperPath"]}
+        pickerOptions={{
+          title: "Locate the Whisper CLI binary",
+          filters: [{ name: "Executable", extensions: ["exe", ""] }],
+        }}
+        onChange={(v) => form.setField("whisperPath", v)}
+        onValidate={() => form.revalidatePath("whisperPath", "executable")}
+        helpText="Path to the compiled whisper-cli (or whisper-cli.exe on Windows)."
+      />
+      <PathPickerField
+        label="Model file"
+        value={form.draft.modelPath}
+        kind="file"
+        validation={form.pathValidations["modelPath"]}
+        pickerOptions={{
+          title: "Locate a Whisper model file",
+          filters: [{ name: "GGML model", extensions: ["bin"] }],
+        }}
+        onChange={(v) => form.setField("modelPath", v)}
+        onValidate={() => form.revalidatePath("modelPath", "file")}
+        helpText="A downloaded .bin model file, e.g. ggml-large-v3-turbo.bin."
+      />
+    </SettingsSection>
+  );
+}

--- a/src/features/settings/useFilePicker.ts
+++ b/src/features/settings/useFilePicker.ts
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { logger } from "../../shared/utils/logger";
+
+export interface FilePickerOptions {
+  title: string;
+  filters?: { name: string; extensions: string[] }[];
+}
+
+/**
+ * Thin hook over the Tauri dialog plugin. Returns a callback that opens the
+ * OS file picker and resolves to the chosen path (or null if the user cancels).
+ *
+ * Kept hook-shaped (rather than a free function) so consumers can test by
+ * swapping the hook in tests via dependency injection if needed.
+ */
+export function useFilePicker() {
+  const pickFile = useCallback(
+    async (options: FilePickerOptions): Promise<string | null> => {
+      try {
+        const selection = await open({
+          multiple: false,
+          directory: false,
+          title: options.title,
+          filters: options.filters,
+        });
+        if (typeof selection === "string") return selection;
+        return null;
+      } catch (error) {
+        logger.error("File picker failed", error);
+        return null;
+      }
+    },
+    []
+  );
+
+  return { pickFile };
+}

--- a/src/features/settings/useSettingsForm.test.ts
+++ b/src/features/settings/useSettingsForm.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { useSettingsForm } from "./useSettingsForm";
+import { MockSettingsService } from "./SettingsService";
+import { ApiProvider } from "../../api";
+import { DEFAULT_APP_CONFIG } from "./appConfig";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => undefined),
+}));
+
+function makeWrapper(settingsService: MockSettingsService) {
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      ApiProvider,
+      {
+        children,
+        services: {
+          sessionService: { getSessions: vi.fn() } as never,
+          recordingService: {} as never,
+          transcriptService: {} as never,
+          clipboardService: {} as never,
+          transcriptionStatsService: {} as never,
+          settingsService,
+          compressionService: {} as never,
+        },
+      }
+    );
+}
+
+describe("useSettingsForm", () => {
+  let svc: MockSettingsService;
+
+  beforeEach(() => {
+    svc = new MockSettingsService();
+  });
+
+  it("loads existing config into baseline + draft on mount", async () => {
+    svc.__setStored({
+      ...DEFAULT_APP_CONFIG,
+      whisperPath: "/seeded/whisper",
+    });
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.draft.whisperPath).toBe("/seeded/whisper");
+    });
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it("tracks dirty when a field changes", async () => {
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setField("whisperPath", "/edited"));
+
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.draft.whisperPath).toBe("/edited");
+  });
+
+  it("cancel reverts draft to baseline", async () => {
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setField("ffmpegPath", "/edited/ffmpeg"));
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => result.current.cancel());
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.draft.ffmpegPath).toBe("");
+  });
+
+  it("save promotes draft into baseline and clears dirty", async () => {
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setField("whisperPath", "/saved"));
+
+    let outcome: { ok: boolean } = { ok: false };
+    await act(async () => {
+      outcome = await result.current.save();
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(result.current.isDirty).toBe(false);
+    expect(svc.__getStored().whisperPath).toBe("/saved");
+  });
+
+  it("setCompressionField updates nested compression state", async () => {
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() =>
+      result.current.setCompressionField("compressNewRecordings", true)
+    );
+    expect(result.current.draft.audioCompression.compressNewRecordings).toBe(
+      true
+    );
+  });
+
+  it("revalidatePath stores the validation result", async () => {
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.setField("ffmpegPath", "/bin/ffmpeg"));
+
+    await act(async () => {
+      await result.current.revalidatePath("ffmpegPath", "ffmpeg");
+    });
+
+    const status = result.current.pathValidations["ffmpegPath"];
+    expect(status?.state).toBe("result");
+    if (status?.state === "result") {
+      expect(status.result.exists).toBe(true);
+      expect(status.result.version).toBe("mock-6.0");
+    }
+  });
+
+  it("stays valid for fresh defaults even with compression on and ffmpeg empty", async () => {
+    // Default has compress-new on with ffmpegPath empty. The path picker's
+    // own status field surfaces the missing-binary state visually; we don't
+    // block save on it.
+    const { result } = renderHook(() => useSettingsForm(), {
+      wrapper: makeWrapper(svc),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.draft.audioCompression.compressNewRecordings).toBe(
+      true
+    );
+    expect(result.current.draft.ffmpegPath).toBe("");
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.fieldErrors.ffmpegPath).toBeUndefined();
+  });
+});

--- a/src/features/settings/useSettingsForm.ts
+++ b/src/features/settings/useSettingsForm.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AppConfig,
+  DEFAULT_APP_CONFIG,
+  PathKind,
+  PathValidation,
+} from "./appConfig";
+import { useApi } from "../../api";
+import {
+  isSettingsDraftDirty,
+  validateSettingsDraft,
+} from "./validateSettingsDraft";
+import { logger } from "../../shared/utils/logger";
+
+export type ValidationStatus =
+  | { state: "idle" }
+  | { state: "checking" }
+  | { state: "result"; result: PathValidation };
+
+export interface SettingsFormState {
+  draft: AppConfig;
+  baseline: AppConfig;
+  isLoading: boolean;
+  isSaving: boolean;
+  loadError: string | null;
+  saveError: string | null;
+  isDirty: boolean;
+  isValid: boolean;
+  fieldErrors: ReturnType<typeof validateSettingsDraft>["fieldErrors"];
+  pathValidations: Record<string, ValidationStatus>;
+}
+
+export interface SettingsFormActions {
+  setField: <K extends keyof AppConfig>(key: K, value: AppConfig[K]) => void;
+  setCompressionField: <K extends keyof AppConfig["audioCompression"]>(
+    key: K,
+    value: AppConfig["audioCompression"][K]
+  ) => void;
+  revalidatePath: (pathField: string, kind: PathKind) => Promise<void>;
+  save: () => Promise<{ ok: boolean }>;
+  cancel: () => void;
+  reload: () => Promise<void>;
+}
+
+/**
+ * Orchestrates the Settings panel: load → edit → validate → save → close.
+ *
+ * Why a hook (rather than open-coded in the component): every transition here
+ * — dirty tracking, debounced validation, save sequencing — is logic that
+ * must not live in JSX per the React Separation doctrine.
+ */
+export function useSettingsForm(): SettingsFormState & SettingsFormActions {
+  const { settingsService } = useApi();
+  const [baseline, setBaseline] = useState<AppConfig>(DEFAULT_APP_CONFIG);
+  const [draft, setDraft] = useState<AppConfig>(DEFAULT_APP_CONFIG);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [pathValidations, setPathValidations] = useState<
+    Record<string, ValidationStatus>
+  >({});
+
+  const validationSequenceRef = useRef<Record<string, number>>({});
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+    try {
+      const config = await settingsService.loadConfig();
+      setBaseline(config);
+      setDraft(config);
+    } catch (error) {
+      logger.error("Failed to load settings", error);
+      setLoadError(
+        error instanceof Error ? error.message : "Failed to load settings"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [settingsService]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const setField = useCallback(
+    <K extends keyof AppConfig>(key: K, value: AppConfig[K]) => {
+      setDraft((prev) => ({ ...prev, [key]: value }));
+    },
+    []
+  );
+
+  const setCompressionField = useCallback(
+    <K extends keyof AppConfig["audioCompression"]>(
+      key: K,
+      value: AppConfig["audioCompression"][K]
+    ) => {
+      setDraft((prev) => ({
+        ...prev,
+        audioCompression: { ...prev.audioCompression, [key]: value },
+      }));
+    },
+    []
+  );
+
+  const revalidatePath = useCallback(
+    async (pathField: string, kind: PathKind) => {
+      const path = readStringField(draft, pathField);
+      const seq = (validationSequenceRef.current[pathField] ?? 0) + 1;
+      validationSequenceRef.current[pathField] = seq;
+      setPathValidations((prev) => ({
+        ...prev,
+        [pathField]: { state: "checking" },
+      }));
+      try {
+        const result = await settingsService.validatePath(path, kind);
+        if (validationSequenceRef.current[pathField] !== seq) return;
+        setPathValidations((prev) => ({
+          ...prev,
+          [pathField]: { state: "result", result },
+        }));
+      } catch (error) {
+        if (validationSequenceRef.current[pathField] !== seq) return;
+        logger.error("Path validation failed", error);
+        setPathValidations((prev) => ({
+          ...prev,
+          [pathField]: {
+            state: "result",
+            result: {
+              exists: false,
+              kind_ok: false,
+              version: null,
+              message: "Validation failed",
+            },
+          },
+        }));
+      }
+    },
+    [draft, settingsService]
+  );
+
+  const save = useCallback(async (): Promise<{ ok: boolean }> => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await settingsService.saveConfig(draft);
+      setBaseline(draft);
+      return { ok: true };
+    } catch (error) {
+      logger.error("Failed to save settings", error);
+      setSaveError(
+        error instanceof Error ? error.message : "Failed to save settings"
+      );
+      return { ok: false };
+    } finally {
+      setIsSaving(false);
+    }
+  }, [draft, settingsService]);
+
+  const cancel = useCallback(() => {
+    setDraft(baseline);
+    setSaveError(null);
+  }, [baseline]);
+
+  const validation = useMemo(() => validateSettingsDraft(draft), [draft]);
+  const isDirty = useMemo(
+    () => isSettingsDraftDirty(baseline, draft),
+    [baseline, draft]
+  );
+
+  return {
+    draft,
+    baseline,
+    isLoading,
+    isSaving,
+    loadError,
+    saveError,
+    isDirty,
+    isValid: validation.isValid,
+    fieldErrors: validation.fieldErrors,
+    pathValidations,
+    setField,
+    setCompressionField,
+    revalidatePath,
+    save,
+    cancel,
+    reload,
+  };
+}
+
+function readStringField(config: AppConfig, key: string): string {
+  const value = (config as unknown as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}

--- a/src/features/settings/useSettingsPanel.ts
+++ b/src/features/settings/useSettingsPanel.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/**
+ * Tauri event fired by the native menu bar's Settings item.
+ * Backed by `MENU_OPEN_SETTINGS_EVENT` in `src-tauri/src/app_menu.rs`.
+ */
+const MENU_OPEN_SETTINGS_EVENT = "menu-open-settings" as const;
+
+/**
+ * Hook that owns the Settings panel's open/closed state.
+ *
+ * Opening happens either from the native menu bar (which also owns the
+ * Ctrl/Cmd+, keyboard accelerator — see `app_menu.rs`) or from any in-app
+ * caller via `open()`.
+ */
+export function useSettingsPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const unlistenPromise = listen(MENU_OPEN_SETTINGS_EVENT, () => {
+      if (!cancelled) setIsOpen(true);
+    });
+    return () => {
+      cancelled = true;
+      void unlistenPromise.then((unlisten) => unlisten()).catch(() => undefined);
+    };
+  }, []);
+
+  return { isOpen, open, close };
+}

--- a/src/features/settings/validateSettingsDraft.test.ts
+++ b/src/features/settings/validateSettingsDraft.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSettingsDraft,
+  isSettingsDraftDirty,
+} from "./validateSettingsDraft";
+import { DEFAULT_APP_CONFIG, AppConfig } from "./appConfig";
+
+function configWith(overrides: Partial<AppConfig>): AppConfig {
+  return {
+    ...DEFAULT_APP_CONFIG,
+    ...overrides,
+    audioCompression: {
+      ...DEFAULT_APP_CONFIG.audioCompression,
+      ...(overrides.audioCompression ?? {}),
+    },
+  };
+}
+
+describe("validateSettingsDraft", () => {
+  it("is valid for fresh defaults (compression off, all paths empty)", () => {
+    const result = validateSettingsDraft(DEFAULT_APP_CONFIG);
+    expect(result.isValid).toBe(true);
+    expect(result.fieldErrors).toEqual({});
+  });
+
+  it("does not block save when ffmpegPath is empty even with compression on", () => {
+    // Missing ffmpeg is surfaced by the path-picker validation status, not by
+    // a save-blocking error; the backend gracefully no-ops compression when
+    // the path is empty.
+    const result = validateSettingsDraft(
+      configWith({
+        audioCompression: {
+          compressNewRecordings: true,
+          compressOldRecordingsEnabled: true,
+          compressOldRecordingsOlderThanDays: 7,
+        },
+      })
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.fieldErrors.ffmpegPath).toBeUndefined();
+  });
+
+  it("accepts compression on when ffmpegPath is set", () => {
+    const result = validateSettingsDraft(
+      configWith({
+        ffmpegPath: "/bin/ffmpeg",
+        audioCompression: {
+          compressNewRecordings: true,
+          compressOldRecordingsEnabled: true,
+          compressOldRecordingsOlderThanDays: 7,
+        },
+      })
+    );
+    expect(result.isValid).toBe(true);
+  });
+
+  it("flags an age threshold not in the supported set", () => {
+    const result = validateSettingsDraft(
+      configWith({
+        ffmpegPath: "/bin/ffmpeg",
+        audioCompression: {
+          compressNewRecordings: false,
+          compressOldRecordingsEnabled: true,
+          compressOldRecordingsOlderThanDays: 99,
+        },
+      })
+    );
+    expect(result.fieldErrors.ageThreshold).toBeDefined();
+  });
+});
+
+describe("isSettingsDraftDirty", () => {
+  it("is false when drafts match", () => {
+    expect(
+      isSettingsDraftDirty(DEFAULT_APP_CONFIG, { ...DEFAULT_APP_CONFIG })
+    ).toBe(false);
+  });
+
+  it("is true when a top-level field differs", () => {
+    expect(
+      isSettingsDraftDirty(
+        DEFAULT_APP_CONFIG,
+        configWith({ whisperPath: "/new/path" })
+      )
+    ).toBe(true);
+  });
+
+  it("is true when a compression subfield differs", () => {
+    // Default has compressNewRecordings true; flipping it should be dirty.
+    expect(
+      isSettingsDraftDirty(
+        DEFAULT_APP_CONFIG,
+        configWith({
+          audioCompression: {
+            compressNewRecordings: false,
+            compressOldRecordingsEnabled: false,
+            compressOldRecordingsOlderThanDays: 7,
+          },
+        })
+      )
+    ).toBe(true);
+  });
+});

--- a/src/features/settings/validateSettingsDraft.ts
+++ b/src/features/settings/validateSettingsDraft.ts
@@ -1,0 +1,50 @@
+import { AppConfig, COMPRESSION_AGE_OPTIONS } from "./appConfig";
+
+export interface SettingsDraftIssues {
+  /** Field-keyed issue messages — empty means valid. */
+  fieldErrors: Partial<Record<keyof AppConfig | "ageThreshold", string>>;
+  /** True when no field has a save-blocking issue. */
+  isValid: boolean;
+}
+
+/**
+ * Pure validation of a settings draft before save.
+ *
+ * Only flags issues that would corrupt persisted state. Missing path values
+ * (Whisper, FFmpeg) are not save-blocking — the user might want to save other
+ * fields and configure binaries later. Runtime features that need a binary
+ * (compression, transcription) gracefully no-op or warn-log when the path is
+ * empty, and the path picker's own validation status already shows a visual
+ * cue ("Not validated" / "File does not exist").
+ */
+export function validateSettingsDraft(draft: AppConfig): SettingsDraftIssues {
+  const fieldErrors: SettingsDraftIssues["fieldErrors"] = {};
+
+  if (
+    !COMPRESSION_AGE_OPTIONS.includes(
+      draft.audioCompression.compressOldRecordingsOlderThanDays
+    )
+  ) {
+    fieldErrors.ageThreshold = `Age threshold must be one of: ${COMPRESSION_AGE_OPTIONS.join(
+      ", "
+    )} days`;
+  }
+
+  return {
+    fieldErrors,
+    isValid: Object.keys(fieldErrors).length === 0,
+  };
+}
+
+/**
+ * Pure dirty check between two settings drafts.
+ *
+ * Pulled out so the hook can reuse it both for the "you have unsaved changes"
+ * indicator and for enabling/disabling the Save button.
+ */
+export function isSettingsDraftDirty(
+  baseline: AppConfig,
+  draft: AppConfig
+): boolean {
+  return JSON.stringify(baseline) !== JSON.stringify(draft);
+}


### PR DESCRIPTION
## Summary
- Adds an in-app Settings panel (`src/features/settings/`) replacing manual edits to `~/Documents/ThoughtCast/config.json`, with file-picker fields, validation, and atomic Rust-side persistence
- Adds an FFmpeg-based audio compression pipeline (`src-tauri/src/recording/compression/`) that runs post-transcription on every new recording and on a cancellable batch sweep, with progress dialog, completion toast, and storage stats UI (`src/features/compression/`)
- Hardens edge cases: orphan-session repair and `.m4a.tmp` cleanup at startup, disk-space guard before batch, and an `transcribing_session_ids` set so the batch worker never touches files currently being recorded or transcribed
- Bumps `tauri` 2.9.2 -> 2.11.1 and `tauri-plugin-dialog` 2.4.2 -> 2.7.1 to match JS-side plugin versions