### PR TITLE
IMPROVE: Add FFmpeg audio chunking for long recordings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "0.2.7-0"
 description = "A Tauri App"
 authors = ["you"]
 license = ""
@@ -29,3 +29,7 @@ hound = "3.5"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
 arboard = "3.3"
+rodio = { version = "0.19", default-features = false, features = ["wav", "mp3", "vorbis", "flac"] }
+
+[target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
+tauri-plugin-global-shortcut = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,9 @@ fn stop_recording(state: State<AppState>, app: tauri::AppHandle) -> Result<Sessi
                     },
                 );
             }
+            TranscriptionResult::Progress(progress) => {
+                let _ = app.emit("transcription-progress", progress);
+            }
             TranscriptionResult::Compressed(compression_event) => {
                 let _ = app.emit("session-audio-compressed", compression_event);
             }

--- a/src-tauri/src/recording/chunking/chunk_planner.rs
+++ b/src-tauri/src/recording/chunking/chunk_planner.rs
@@ -1,0 +1,263 @@
+//! Pure planning logic: given the audio duration and silences detected within
+//! it, decide where to cut the WAV. Kept free of FFmpeg / filesystem concerns
+//! so the planning policy is straightforwardly unit-testable.
+
+use serde::Serialize;
+
+/// A range of audio time (seconds) where FFmpeg's `silencedetect` reported
+/// the signal stayed under the configured threshold.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SilenceRange {
+    pub start_sec: f64,
+    pub end_sec: f64,
+}
+
+/// One chunk to feed to Whisper. End-exclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub struct ChunkSpec {
+    pub start_sec: f64,
+    pub end_sec: f64,
+}
+
+/// Output of the planner. `used_fallback` is set when the planner had to cut
+/// at the max-window boundary because no silence was found in the target
+/// range — the user can be warned the seam may be rougher than usual.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChunkPlan {
+    pub chunks: Vec<ChunkSpec>,
+    pub used_fallback: bool,
+}
+
+/// Lead-in (seconds) the planner adds after the silence end so the next chunk
+/// starts on speech rather than at the tail of the silence. Small — just
+/// enough that Whisper doesn't see a hard transition at sample 0.
+///
+/// Per the PRD: "Each new chunk starts a fraction of a second after the
+/// silence ends, giving the model lead-in context". 50ms is enough to avoid
+/// landing exactly on the silence-end sample but short enough that the
+/// previous chunk's tail still carries the trailing phoneme if any.
+const LEAD_IN_AFTER_SILENCE_SEC: f64 = 0.05;
+
+/// Decide chunk boundaries for a recording.
+///
+/// Rules:
+/// * `audio_duration_sec` < `min_chunk_duration_sec` → single chunk equal to
+///   the whole recording. Chunking is a no-op for short recordings.
+/// * Otherwise walk the recording: for each cursor position, look in the
+///   `[cursor + min, cursor + max]` window for the *latest* silence whose
+///   start falls inside the window. Cut at silence start, resume the next
+///   chunk at silence end + lead-in.
+/// * If no silence sits in the window, fall back to a hard cut at
+///   `cursor + max` and flag `used_fallback`.
+pub fn plan_cuts(
+    audio_duration_sec: f64,
+    silences: &[SilenceRange],
+    min_chunk_duration_sec: f64,
+    max_chunk_duration_sec: f64,
+) -> ChunkPlan {
+    if audio_duration_sec <= 0.0 {
+        return ChunkPlan {
+            chunks: Vec::new(),
+            used_fallback: false,
+        };
+    }
+
+    // Sanity: invalid config (max <= min) collapses to a single chunk so we
+    // never produce an infinite loop. Validation upstream should already
+    // prevent this, but defending in depth.
+    if max_chunk_duration_sec <= min_chunk_duration_sec
+        || audio_duration_sec < min_chunk_duration_sec
+    {
+        return ChunkPlan {
+            chunks: vec![ChunkSpec {
+                start_sec: 0.0,
+                end_sec: audio_duration_sec,
+            }],
+            used_fallback: false,
+        };
+    }
+
+    let mut chunks: Vec<ChunkSpec> = Vec::new();
+    let mut cursor = 0.0_f64;
+    let mut used_fallback = false;
+
+    while audio_duration_sec - cursor > max_chunk_duration_sec {
+        let window_lo = cursor + min_chunk_duration_sec;
+        let window_hi = cursor + max_chunk_duration_sec;
+
+        let candidate = silences
+            .iter()
+            .filter(|s| s.start_sec >= window_lo && s.start_sec <= window_hi)
+            // Prefer the latest silence in the window — gives the model the
+            // most speech context per chunk while staying under the max.
+            .max_by(|a, b| {
+                a.start_sec
+                    .partial_cmp(&b.start_sec)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        match candidate {
+            Some(silence) => {
+                chunks.push(ChunkSpec {
+                    start_sec: cursor,
+                    end_sec: silence.start_sec,
+                });
+                cursor = (silence.end_sec + LEAD_IN_AFTER_SILENCE_SEC)
+                    .min(audio_duration_sec);
+            }
+            None => {
+                // No silence in window — hard-cut at max and warn.
+                chunks.push(ChunkSpec {
+                    start_sec: cursor,
+                    end_sec: window_hi,
+                });
+                cursor = window_hi;
+                used_fallback = true;
+            }
+        }
+    }
+
+    // Final tail: whatever remains after the last cut goes in one chunk.
+    if cursor < audio_duration_sec {
+        chunks.push(ChunkSpec {
+            start_sec: cursor,
+            end_sec: audio_duration_sec,
+        });
+    }
+
+    ChunkPlan {
+        chunks,
+        used_fallback,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn silence(start: f64, end: f64) -> SilenceRange {
+        SilenceRange {
+            start_sec: start,
+            end_sec: end,
+        }
+    }
+
+    #[test]
+    fn test_plan_short_audio_returns_single_chunk() {
+        let plan = plan_cuts(120.0, &[], 420.0, 600.0);
+        assert_eq!(plan.chunks.len(), 1);
+        assert_eq!(plan.chunks[0].start_sec, 0.0);
+        assert_eq!(plan.chunks[0].end_sec, 120.0);
+        assert!(!plan.used_fallback);
+    }
+
+    #[test]
+    fn test_plan_zero_duration_returns_no_chunks() {
+        let plan = plan_cuts(0.0, &[], 420.0, 600.0);
+        assert!(plan.chunks.is_empty());
+        assert!(!plan.used_fallback);
+    }
+
+    #[test]
+    fn test_plan_uses_silence_within_window() {
+        // 25-min recording, silences at 8min and 17min (in window).
+        let silences = vec![silence(8.0 * 60.0, 8.5 * 60.0), silence(17.0 * 60.0, 17.4 * 60.0)];
+        let plan = plan_cuts(25.0 * 60.0, &silences, 420.0, 600.0);
+
+        assert_eq!(plan.chunks.len(), 3);
+        assert!(!plan.used_fallback);
+
+        // First chunk: 0 → silence_start (8min)
+        assert_eq!(plan.chunks[0].start_sec, 0.0);
+        assert!((plan.chunks[0].end_sec - 8.0 * 60.0).abs() < 0.001);
+
+        // Second chunk starts at silence_end + lead-in (~8.5min + 0.05s)
+        assert!((plan.chunks[1].start_sec - (8.5 * 60.0 + LEAD_IN_AFTER_SILENCE_SEC)).abs() < 0.001);
+        assert!((plan.chunks[1].end_sec - 17.0 * 60.0).abs() < 0.001);
+
+        // Third chunk runs to end
+        assert!((plan.chunks[2].end_sec - 25.0 * 60.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_plan_falls_back_to_hard_cut_when_no_silence_in_window() {
+        // 15-min recording with one continuous monologue — no silence at all.
+        let plan = plan_cuts(15.0 * 60.0, &[], 420.0, 600.0);
+
+        // Should split at max (10min) then carry the 5-min remainder.
+        assert_eq!(plan.chunks.len(), 2);
+        assert!(plan.used_fallback);
+        assert!((plan.chunks[0].end_sec - 600.0).abs() < 0.001);
+        assert!((plan.chunks[1].start_sec - 600.0).abs() < 0.001);
+        assert!((plan.chunks[1].end_sec - 900.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_plan_ignores_silences_outside_window() {
+        // Silence at 5min (before min=7min) and one at 11min (after max=10min).
+        // Neither is usable for the first cut — must fall back.
+        let silences = vec![silence(5.0 * 60.0, 5.2 * 60.0), silence(11.0 * 60.0, 11.2 * 60.0)];
+        let plan = plan_cuts(20.0 * 60.0, &silences, 420.0, 600.0);
+
+        assert!(plan.used_fallback, "first cut should fall back");
+        assert!(
+            (plan.chunks[0].end_sec - 600.0).abs() < 0.001,
+            "first cut should be at max"
+        );
+    }
+
+    #[test]
+    fn test_plan_prefers_latest_silence_in_window() {
+        // Two silences inside the [7min, 10min] window — planner should pick
+        // the later one to maximize speech-per-chunk. We only assert on the
+        // FIRST cut here; whether the tail needs a fallback later depends on
+        // unrelated tail silences and is covered separately.
+        let silences = vec![silence(7.5 * 60.0, 7.6 * 60.0), silence(9.5 * 60.0, 9.6 * 60.0)];
+        let plan = plan_cuts(20.0 * 60.0, &silences, 420.0, 600.0);
+
+        assert!(
+            (plan.chunks[0].end_sec - 9.5 * 60.0).abs() < 0.001,
+            "expected first cut at 9.5min (latest silence), got {}",
+            plan.chunks[0].end_sec
+        );
+    }
+
+    #[test]
+    fn test_plan_applies_lead_in_offset_after_silence_end() {
+        let silences = vec![silence(8.0 * 60.0, 9.0 * 60.0)]; // 1-min silence
+        let plan = plan_cuts(20.0 * 60.0, &silences, 420.0, 600.0);
+
+        // Second chunk should start at 9min + 50ms (lead-in), not 9min flat.
+        let expected_start = 9.0 * 60.0 + LEAD_IN_AFTER_SILENCE_SEC;
+        assert!((plan.chunks[1].start_sec - expected_start).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_plan_handles_multiple_chunks_for_very_long_audio() {
+        // 27-min recording with regular silences every ~8 minutes. After the
+        // third cut at 24min the remaining ~3min fits inside one tail chunk
+        // without needing a fallback.
+        let silences = vec![
+            silence(8.0 * 60.0, 8.1 * 60.0),
+            silence(16.0 * 60.0, 16.1 * 60.0),
+            silence(24.0 * 60.0, 24.1 * 60.0),
+        ];
+        let plan = plan_cuts(27.0 * 60.0, &silences, 420.0, 600.0);
+
+        assert!(!plan.used_fallback);
+        assert_eq!(plan.chunks.len(), 4);
+        assert!((plan.chunks[0].end_sec - 8.0 * 60.0).abs() < 0.001);
+        assert!((plan.chunks[1].end_sec - 16.0 * 60.0).abs() < 0.001);
+        assert!((plan.chunks[2].end_sec - 24.0 * 60.0).abs() < 0.001);
+        assert!((plan.chunks[3].end_sec - 27.0 * 60.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_plan_invalid_config_collapses_to_single_chunk() {
+        // max < min — defend in depth (UI validation should already block this).
+        let plan = plan_cuts(1200.0, &[], 600.0, 300.0);
+        assert_eq!(plan.chunks.len(), 1);
+        assert_eq!(plan.chunks[0].end_sec, 1200.0);
+        assert!(!plan.used_fallback);
+    }
+}

--- a/src-tauri/src/recording/chunking/errors.rs
+++ b/src-tauri/src/recording/chunking/errors.rs
@@ -1,0 +1,35 @@
+use serde::Serialize;
+use std::fmt;
+
+/// Structured failure modes for the silence-detect chunking pipeline.
+///
+/// Mirrors `compression::errors::CompressionError`'s shape so the same
+/// "missing FFmpeg → silently disable, other errors → surface" disposition
+/// logic can be reused at the orchestrator level.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ChunkingError {
+    FfmpegMissing { message: String },
+    FfmpegFailed { message: String },
+    Io { message: String },
+}
+
+impl fmt::Display for ChunkingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChunkingError::FfmpegMissing { message }
+            | ChunkingError::FfmpegFailed { message }
+            | ChunkingError::Io { message } => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for ChunkingError {}
+
+impl From<std::io::Error> for ChunkingError {
+    fn from(value: std::io::Error) -> Self {
+        ChunkingError::Io {
+            message: value.to_string(),
+        }
+    }
+}

--- a/src-tauri/src/recording/chunking/mod.rs
+++ b/src-tauri/src/recording/chunking/mod.rs
@@ -1,0 +1,74 @@
+//! Silence-detect-based chunking of long recordings.
+//!
+//! - `silence_detector`: runs `ffmpeg -af silencedetect` and parses stderr
+//! - `chunk_planner`: pure function that turns silence ranges into cut points
+//! - `wav_splitter`: writes per-chunk WAV files via FFmpeg
+//! - `errors`: structured failure modes shared across the module
+//!
+//! The orchestrator (in `transcription::chunked_orchestrator`) drives this
+//! module sequentially: detect → plan → split → transcribe chunks → stitch.
+
+pub mod chunk_planner;
+pub mod errors;
+pub mod silence_detector;
+pub mod wav_splitter;
+
+pub use chunk_planner::plan_cuts;
+pub use errors::ChunkingError;
+pub use silence_detector::detect_silences;
+pub use wav_splitter::split_wav;
+
+use crate::recording::models::AudioChunkingConfig;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+/// Result of running silence detection, planning, and splitting on a WAV.
+/// The orchestrator uses this to drive sequential transcription and to
+/// record chunking telemetry on the session.
+#[derive(Debug)]
+pub struct ChunkingOutcome {
+    /// Per-chunk WAV files, in playback order. Caller owns cleanup.
+    pub chunk_files: Vec<PathBuf>,
+    /// Wall-clock seconds the silence-detect + split pass took.
+    pub analysis_seconds: f64,
+    /// True if the planner had to fall back to a hard cut for any window.
+    pub used_fallback: bool,
+}
+
+/// Run the full plan-and-split pass: silence detect, plan, write chunk files.
+///
+/// `audio_duration_sec` is the recording's duration — used by the planner to
+/// decide whether chunking is needed at all. `output_dir` must already exist;
+/// the caller owns it and is responsible for cleanup once transcription is
+/// done.
+pub fn plan_and_split(
+    ffmpeg_path: &str,
+    source_wav: &Path,
+    audio_duration_sec: f64,
+    config: &AudioChunkingConfig,
+    output_dir: &Path,
+) -> Result<ChunkingOutcome, ChunkingError> {
+    let start = Instant::now();
+
+    let silences = detect_silences(
+        ffmpeg_path,
+        source_wav,
+        config.silence_threshold_db,
+        config.min_silence_duration_sec,
+    )?;
+
+    let plan = plan_cuts(
+        audio_duration_sec,
+        &silences,
+        config.min_chunk_duration_sec,
+        config.max_chunk_duration_sec,
+    );
+
+    let chunk_files = split_wav(ffmpeg_path, source_wav, &plan.chunks, output_dir)?;
+
+    Ok(ChunkingOutcome {
+        chunk_files,
+        analysis_seconds: start.elapsed().as_secs_f64(),
+        used_fallback: plan.used_fallback,
+    })
+}

--- a/src-tauri/src/recording/chunking/silence_detector.rs
+++ b/src-tauri/src/recording/chunking/silence_detector.rs
@@ -1,0 +1,227 @@
+//! Detects silence ranges in a WAV file by invoking
+//! `ffmpeg -af silencedetect=noise=<dB>:d=<sec> -f null -` and parsing the
+//! `silence_start` / `silence_end` markers FFmpeg writes to stderr.
+
+use super::chunk_planner::SilenceRange;
+use super::errors::ChunkingError;
+use crate::recording::utils::apply_no_console_window;
+use std::path::Path;
+use std::process::Command;
+
+/// Run silence detection on `wav_path` and return the detected ranges.
+///
+/// `threshold_db` is the `noise=` parameter (typically negative — quieter
+/// than the threshold counts as silence). `min_silence_duration_sec` is the
+/// `d=` parameter (the shortest run that qualifies).
+pub fn detect_silences(
+    ffmpeg_path: &str,
+    wav_path: &Path,
+    threshold_db: f64,
+    min_silence_duration_sec: f64,
+) -> Result<Vec<SilenceRange>, ChunkingError> {
+    if ffmpeg_path.trim().is_empty() {
+        return Err(ChunkingError::FfmpegMissing {
+            message: "FFmpeg path is not configured".to_string(),
+        });
+    }
+    if !Path::new(ffmpeg_path).exists() {
+        return Err(ChunkingError::FfmpegMissing {
+            message: format!("FFmpeg binary not found at: {}", ffmpeg_path),
+        });
+    }
+    if !wav_path.exists() {
+        return Err(ChunkingError::Io {
+            message: format!("Source WAV not found: {}", wav_path.display()),
+        });
+    }
+
+    let output = build_silencedetect_command(
+        ffmpeg_path,
+        wav_path,
+        threshold_db,
+        min_silence_duration_sec,
+    )
+    .output()
+    .map_err(|e| ChunkingError::FfmpegFailed {
+        message: format!("Could not launch FFmpeg for silence detection: {}", e),
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(ChunkingError::FfmpegFailed {
+            message: format!("FFmpeg silencedetect exited with error: {}", stderr.trim()),
+        });
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    Ok(parse_silencedetect_stderr(&stderr))
+}
+
+fn build_silencedetect_command(
+    ffmpeg_path: &str,
+    wav_path: &Path,
+    threshold_db: f64,
+    min_silence_duration_sec: f64,
+) -> Command {
+    let filter = format!(
+        "silencedetect=noise={}dB:d={}",
+        threshold_db, min_silence_duration_sec
+    );
+
+    let mut cmd = Command::new(ffmpeg_path);
+    cmd.arg("-hide_banner")
+        .arg("-nostats")
+        .arg("-i")
+        .arg(wav_path)
+        .arg("-af")
+        .arg(&filter)
+        // No audio output — we only care about the filter's stderr markers.
+        .arg("-f")
+        .arg("null")
+        .arg("-");
+
+    apply_no_console_window(&mut cmd);
+    cmd
+}
+
+/// Parse FFmpeg `silencedetect` stderr lines like:
+///   `[silencedetect @ 0x...] silence_start: 12.345`
+///   `[silencedetect @ 0x...] silence_end: 13.012 | silence_duration: 0.667`
+///
+/// Pairs them into `SilenceRange`s. Unmatched `silence_start` markers
+/// (silence that runs to end-of-file) are dropped — they can't be used as
+/// cut points anyway.
+fn parse_silencedetect_stderr(stderr: &str) -> Vec<SilenceRange> {
+    let mut ranges: Vec<SilenceRange> = Vec::new();
+    let mut pending_start: Option<f64> = None;
+
+    for line in stderr.lines() {
+        if let Some(start) = extract_marker(line, "silence_start:") {
+            pending_start = Some(start);
+        } else if let Some(end) = extract_marker(line, "silence_end:") {
+            if let Some(start) = pending_start.take() {
+                if end > start {
+                    ranges.push(SilenceRange {
+                        start_sec: start,
+                        end_sec: end,
+                    });
+                }
+            }
+        }
+    }
+
+    ranges
+}
+
+/// Extract the floating-point value that follows `marker` on a stderr line.
+/// Returns `None` if the marker isn't present or the value doesn't parse.
+fn extract_marker(line: &str, marker: &str) -> Option<f64> {
+    let idx = line.find(marker)?;
+    let rest = &line[idx + marker.len()..];
+    let token = rest.split_whitespace().next()?;
+    token.parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_single_silence_pair() {
+        let stderr = "\
+[silencedetect @ 0x55aa] silence_start: 12.345
+[silencedetect @ 0x55aa] silence_end: 13.012 | silence_duration: 0.667
+";
+        let ranges = parse_silencedetect_stderr(stderr);
+        assert_eq!(ranges.len(), 1);
+        assert!((ranges[0].start_sec - 12.345).abs() < 0.0001);
+        assert!((ranges[0].end_sec - 13.012).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_parse_multiple_silences_in_order() {
+        let stderr = "\
+[silencedetect] silence_start: 5.0
+[silencedetect] silence_end: 5.5 | silence_duration: 0.5
+random noise output from ffmpeg
+[silencedetect] silence_start: 480.123
+[silencedetect] silence_end: 481.0 | silence_duration: 0.877
+";
+        let ranges = parse_silencedetect_stderr(stderr);
+        assert_eq!(ranges.len(), 2);
+        assert!((ranges[1].start_sec - 480.123).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_parse_drops_unmatched_silence_start() {
+        // Recording ends mid-silence — silencedetect emits only `silence_start`.
+        let stderr = "[silencedetect] silence_start: 600.0\n";
+        let ranges = parse_silencedetect_stderr(stderr);
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn test_parse_handles_empty_stderr() {
+        let ranges = parse_silencedetect_stderr("");
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn test_parse_ignores_zero_or_negative_duration() {
+        // Bogus data shouldn't crash — silence_end before silence_start.
+        let stderr = "\
+[silencedetect] silence_start: 12.0
+[silencedetect] silence_end: 11.0 | silence_duration: -1.0
+";
+        let ranges = parse_silencedetect_stderr(stderr);
+        assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn test_build_command_contains_filter_and_null_output() {
+        let cmd = build_silencedetect_command(
+            "/usr/bin/ffmpeg",
+            Path::new("/tmp/test.wav"),
+            -35.0,
+            0.5,
+        );
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        let filter_idx = args.iter().position(|a| a == "-af").expect("missing -af");
+        let filter = &args[filter_idx + 1];
+        assert!(filter.contains("silencedetect"));
+        assert!(filter.contains("noise=-35dB"));
+        assert!(filter.contains("d=0.5"));
+
+        // Output is null format on stdout
+        assert!(args.iter().any(|a| a == "null"));
+        assert!(args.iter().any(|a| a == "-"));
+    }
+
+    #[test]
+    fn test_detect_returns_error_for_empty_ffmpeg_path() {
+        let err = detect_silences("", Path::new("/tmp/x.wav"), -35.0, 0.5).unwrap_err();
+        match err {
+            ChunkingError::FfmpegMissing { .. } => {}
+            other => panic!("expected FfmpegMissing, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_detect_returns_error_for_nonexistent_ffmpeg() {
+        let err = detect_silences(
+            "/definitely/does/not/exist/ffmpeg",
+            Path::new("/tmp/x.wav"),
+            -35.0,
+            0.5,
+        )
+        .unwrap_err();
+        match err {
+            ChunkingError::FfmpegMissing { .. } => {}
+            other => panic!("expected FfmpegMissing, got {:?}", other),
+        }
+    }
+}

--- a/src-tauri/src/recording/chunking/wav_splitter.rs
+++ b/src-tauri/src/recording/chunking/wav_splitter.rs
@@ -1,0 +1,177 @@
+//! Splits a source WAV into per-chunk WAVs at the time offsets the planner
+//! produced. Re-encodes to PCM s16le 16kHz mono so each chunk matches what
+//! Whisper.cpp expects (the recording pipeline already writes 16kHz mono,
+//! but the explicit `-ar 16000 -ac 1` makes the chunk path tolerant of any
+//! future format drift).
+
+use super::chunk_planner::ChunkSpec;
+use super::errors::ChunkingError;
+use crate::recording::utils::apply_no_console_window;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Write each chunk in `chunks` to a separate WAV file under `output_dir`.
+/// Files are named `chunk_000.wav`, `chunk_001.wav`, ... and the returned
+/// vector preserves chunk order so the caller can transcribe sequentially.
+///
+/// `output_dir` must already exist — typically a temp directory the caller
+/// owns and cleans up after transcription completes.
+pub fn split_wav(
+    ffmpeg_path: &str,
+    source_wav: &Path,
+    chunks: &[ChunkSpec],
+    output_dir: &Path,
+) -> Result<Vec<PathBuf>, ChunkingError> {
+    if ffmpeg_path.trim().is_empty() {
+        return Err(ChunkingError::FfmpegMissing {
+            message: "FFmpeg path is not configured".to_string(),
+        });
+    }
+    if !Path::new(ffmpeg_path).exists() {
+        return Err(ChunkingError::FfmpegMissing {
+            message: format!("FFmpeg binary not found at: {}", ffmpeg_path),
+        });
+    }
+    if !source_wav.exists() {
+        return Err(ChunkingError::Io {
+            message: format!("Source WAV not found: {}", source_wav.display()),
+        });
+    }
+    if !output_dir.exists() {
+        return Err(ChunkingError::Io {
+            message: format!(
+                "Chunk output directory does not exist: {}",
+                output_dir.display()
+            ),
+        });
+    }
+
+    let mut written: Vec<PathBuf> = Vec::with_capacity(chunks.len());
+
+    for (idx, chunk) in chunks.iter().enumerate() {
+        let chunk_path = output_dir.join(format!("chunk_{:03}.wav", idx));
+        let duration = chunk.end_sec - chunk.start_sec;
+        if duration <= 0.0 {
+            return Err(ChunkingError::Io {
+                message: format!(
+                    "Chunk {} has non-positive duration ({:.3}s)",
+                    idx, duration
+                ),
+            });
+        }
+
+        let output = build_split_command(ffmpeg_path, source_wav, &chunk_path, chunk)
+            .output()
+            .map_err(|e| ChunkingError::FfmpegFailed {
+                message: format!("Could not launch FFmpeg to split chunk {}: {}", idx, e),
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(ChunkingError::FfmpegFailed {
+                message: format!(
+                    "FFmpeg exited with error splitting chunk {}: {}",
+                    idx,
+                    stderr.trim()
+                ),
+            });
+        }
+
+        if !chunk_path.exists() {
+            return Err(ChunkingError::FfmpegFailed {
+                message: format!(
+                    "FFmpeg reported success but chunk file was not written: {}",
+                    chunk_path.display()
+                ),
+            });
+        }
+
+        written.push(chunk_path);
+    }
+
+    Ok(written)
+}
+
+fn build_split_command(
+    ffmpeg_path: &str,
+    source_wav: &Path,
+    chunk_path: &Path,
+    chunk: &ChunkSpec,
+) -> Command {
+    let duration = chunk.end_sec - chunk.start_sec;
+    let mut cmd = Command::new(ffmpeg_path);
+    cmd.arg("-y") // overwrite (paths are scoped to a temp dir we own)
+        .arg("-hide_banner")
+        .arg("-loglevel")
+        .arg("error")
+        // `-ss` *before* `-i` does input-side seek — fast and frame-accurate
+        // enough for our use (the underlying file is PCM, no keyframes).
+        .arg("-ss")
+        .arg(format!("{}", chunk.start_sec))
+        .arg("-i")
+        .arg(source_wav)
+        .arg("-t")
+        .arg(format!("{}", duration))
+        .arg("-ar")
+        .arg("16000")
+        .arg("-ac")
+        .arg("1")
+        .arg("-c:a")
+        .arg("pcm_s16le")
+        .arg(chunk_path);
+
+    apply_no_console_window(&mut cmd);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_command_includes_ss_t_and_pcm_args() {
+        let chunk = ChunkSpec {
+            start_sec: 480.0,
+            end_sec: 1080.0,
+        };
+        let cmd = build_split_command(
+            "/usr/bin/ffmpeg",
+            Path::new("/tmp/in.wav"),
+            Path::new("/tmp/chunk_001.wav"),
+            &chunk,
+        );
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        let ss_idx = args.iter().position(|a| a == "-ss").expect("missing -ss");
+        assert_eq!(args[ss_idx + 1], "480");
+
+        let t_idx = args.iter().position(|a| a == "-t").expect("missing -t");
+        assert_eq!(args[t_idx + 1], "600");
+
+        assert!(args.iter().any(|a| a == "pcm_s16le"));
+        assert!(args.iter().any(|a| a == "16000"));
+    }
+
+    #[test]
+    fn test_split_returns_error_for_empty_ffmpeg_path() {
+        let dummy = ChunkSpec {
+            start_sec: 0.0,
+            end_sec: 1.0,
+        };
+        let err = split_wav(
+            "",
+            Path::new("/tmp/in.wav"),
+            &[dummy],
+            Path::new("/tmp"),
+        )
+        .unwrap_err();
+        match err {
+            ChunkingError::FfmpegMissing { .. } => {}
+            other => panic!("expected FfmpegMissing, got {:?}", other),
+        }
+    }
+}

--- a/src-tauri/src/recording/compression/eligibility.rs
+++ b/src-tauri/src/recording/compression/eligibility.rs
@@ -76,6 +76,9 @@ mod tests {
             clipboard_copied: false,
             transcription_time_seconds: None,
             model_path: None,
+            chunking_analysis_seconds: None,
+            chunk_count: None,
+            chunking_used_fallback: None,
         }
     }
 

--- a/src-tauri/src/recording/compression/ffmpeg_runner.rs
+++ b/src-tauri/src/recording/compression/ffmpeg_runner.rs
@@ -1,4 +1,5 @@
 use super::errors::CompressionError;
+use crate::recording::utils::apply_no_console_window;
 use std::path::Path;
 use std::process::Command;
 
@@ -84,13 +85,7 @@ fn build_ffmpeg_command(ffmpeg_path: &str, wav_path: &Path, m4a_temp_path: &Path
         .arg("ipod")
         .arg(m4a_temp_path);
 
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
-        cmd.creation_flags(CREATE_NO_WINDOW);
-    }
-
+    apply_no_console_window(&mut cmd);
     cmd
 }
 

--- a/src-tauri/src/recording/mod.rs
+++ b/src-tauri/src/recording/mod.rs
@@ -1,5 +1,6 @@
 // Core modules
 mod audio;
+mod chunking;
 mod compression;
 mod config;
 mod models;

--- a/src-tauri/src/recording/models.rs
+++ b/src-tauri/src/recording/models.rs
@@ -18,6 +18,19 @@ pub struct Session {
     /// Model used for transcription (for filtering estimates by model)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_path: Option<String>,
+    /// Wall-clock seconds the silence-detect + split pass took. None for
+    /// recordings that bypassed chunking (short, or chunking disabled).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunking_analysis_seconds: Option<f64>,
+    /// Number of chunks the recording was split into. None when chunking did
+    /// not run; 1 when the planner decided no split was needed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunk_count: Option<u32>,
+    /// True when the planner had to fall back to a hard cut because no
+    /// silence was found in the configured window. Surfaced in the UI so the
+    /// user knows the seam may be rougher than usual.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chunking_used_fallback: Option<bool>,
 }
 
 /// Index containing all recording sessions
@@ -108,6 +121,62 @@ impl Default for KeyboardShortcutsConfig {
     }
 }
 
+/// Silence-detect-based chunking of long recordings before transcription,
+/// persisted under `audioChunking` in config.json.
+///
+/// Fields are stored in SI units (seconds, dB) to match FFmpeg's
+/// `silencedetect` filter directly and avoid unit conversions in the Rust
+/// code path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioChunkingConfig {
+    #[serde(rename = "enabled", default = "default_chunking_enabled")]
+    pub enabled: bool,
+    /// Minimum chunk length in seconds. Recordings shorter than this skip
+    /// chunking entirely (no-op fast path).
+    #[serde(rename = "minChunkDurationSec", default = "default_min_chunk_duration_sec")]
+    pub min_chunk_duration_sec: f64,
+    /// Maximum chunk length in seconds. If no silence is found within
+    /// [min, max] the planner falls back to a hard cut at this offset.
+    #[serde(rename = "maxChunkDurationSec", default = "default_max_chunk_duration_sec")]
+    pub max_chunk_duration_sec: f64,
+    /// Silence threshold in dB (negative — quieter than the threshold counts
+    /// as silence). FFmpeg's `noise=` parameter.
+    #[serde(rename = "silenceThresholdDb", default = "default_silence_threshold_db")]
+    pub silence_threshold_db: f64,
+    /// Minimum continuous silence length, in seconds, to count as a cut
+    /// candidate. FFmpeg's `d=` parameter.
+    #[serde(rename = "minSilenceDurationSec", default = "default_min_silence_duration_sec")]
+    pub min_silence_duration_sec: f64,
+}
+
+fn default_chunking_enabled() -> bool {
+    true
+}
+fn default_min_chunk_duration_sec() -> f64 {
+    7.0 * 60.0
+}
+fn default_max_chunk_duration_sec() -> f64 {
+    10.0 * 60.0
+}
+fn default_silence_threshold_db() -> f64 {
+    -35.0
+}
+fn default_min_silence_duration_sec() -> f64 {
+    0.5
+}
+
+impl Default for AudioChunkingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_chunking_enabled(),
+            min_chunk_duration_sec: default_min_chunk_duration_sec(),
+            max_chunk_duration_sec: default_max_chunk_duration_sec(),
+            silence_threshold_db: default_silence_threshold_db(),
+            min_silence_duration_sec: default_min_silence_duration_sec(),
+        }
+    }
+}
+
 /// Audio feedback (cue) configuration, persisted under `audioFeedback` in config.json.
 ///
 /// Empty `*_cue_path` strings mean "use the bundled default at
@@ -166,6 +235,8 @@ pub struct AppConfig {
     pub keyboard_shortcuts: KeyboardShortcutsConfig,
     #[serde(rename = "audioFeedback", default)]
     pub audio_feedback: AudioFeedbackConfig,
+    #[serde(rename = "audioChunking", default)]
+    pub audio_chunking: AudioChunkingConfig,
 }
 
 impl Default for AppConfig {
@@ -178,6 +249,7 @@ impl Default for AppConfig {
             audio_compression: AudioCompressionConfig::default(),
             keyboard_shortcuts: KeyboardShortcutsConfig::default(),
             audio_feedback: AudioFeedbackConfig::default(),
+            audio_chunking: AudioChunkingConfig::default(),
         }
     }
 }
@@ -215,6 +287,9 @@ mod tests {
             clipboard_copied: true,
             transcription_time_seconds: Some(6.8),
             model_path: Some("/path/to/model.bin".to_string()),
+            chunking_analysis_seconds: None,
+            chunk_count: None,
+            chunking_used_fallback: None,
         };
 
         let json = serde_json::to_string(&session).unwrap();
@@ -265,6 +340,9 @@ mod tests {
                 clipboard_copied: true,
                 transcription_time_seconds: Some(4.5),
                 model_path: Some("/model.bin".to_string()),
+                chunking_analysis_seconds: None,
+                chunk_count: None,
+                chunking_used_fallback: None,
             },
             Session {
                 id: "session2".to_string(),
@@ -276,6 +354,9 @@ mod tests {
                 clipboard_copied: false,
                 transcription_time_seconds: None,
                 model_path: None,
+                chunking_analysis_seconds: None,
+                chunk_count: None,
+                chunking_used_fallback: None,
             },
         ];
 
@@ -442,5 +523,72 @@ mod tests {
         let ptt_json = serde_json::to_string(&TriggerMode::PushToTalk).unwrap();
         assert_eq!(toggle_json, "\"toggle\"");
         assert_eq!(ptt_json, "\"push-to-talk\"");
+    }
+
+    #[test]
+    fn test_audio_chunking_defaults() {
+        let cfg = AudioChunkingConfig::default();
+        assert!(cfg.enabled, "chunking should default on");
+        assert_eq!(cfg.min_chunk_duration_sec, 420.0);
+        assert_eq!(cfg.max_chunk_duration_sec, 600.0);
+        assert_eq!(cfg.silence_threshold_db, -35.0);
+        assert!((cfg.min_silence_duration_sec - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_app_config_round_trip_with_chunking() {
+        let config = AppConfig {
+            audio_chunking: AudioChunkingConfig {
+                enabled: false,
+                min_chunk_duration_sec: 300.0,
+                max_chunk_duration_sec: 480.0,
+                silence_threshold_db: -42.0,
+                min_silence_duration_sec: 0.8,
+            },
+            ..AppConfig::default()
+        };
+
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: AppConfig = serde_json::from_str(&json).unwrap();
+
+        assert!(!parsed.audio_chunking.enabled);
+        assert_eq!(parsed.audio_chunking.min_chunk_duration_sec, 300.0);
+        assert_eq!(parsed.audio_chunking.max_chunk_duration_sec, 480.0);
+        assert_eq!(parsed.audio_chunking.silence_threshold_db, -42.0);
+        assert!((parsed.audio_chunking.min_silence_duration_sec - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_legacy_config_defaults_chunking_enabled() {
+        // A config from before chunking landed must keep working and adopt
+        // the new "chunking on" default without manual migration.
+        let json = r#"{
+            "whisperPath": "/usr/bin/whisper",
+            "modelPath": "/models/base.bin"
+        }"#;
+
+        let config: AppConfig = serde_json::from_str(json).unwrap();
+        assert!(config.audio_chunking.enabled);
+        assert_eq!(config.audio_chunking.min_chunk_duration_sec, 420.0);
+        assert_eq!(config.audio_chunking.max_chunk_duration_sec, 600.0);
+    }
+
+    #[test]
+    fn test_session_round_trips_chunking_telemetry() {
+        let json = r#"{
+            "id": "test-id",
+            "timestamp": "2024-11-02T15:30:00Z",
+            "audio_path": "audio/test.wav",
+            "duration": 1500.0,
+            "preview": "Test",
+            "chunking_analysis_seconds": 4.2,
+            "chunk_count": 3,
+            "chunking_used_fallback": false
+        }"#;
+
+        let session: Session = serde_json::from_str(json).unwrap();
+        assert_eq!(session.chunking_analysis_seconds, Some(4.2));
+        assert_eq!(session.chunk_count, Some(3));
+        assert_eq!(session.chunking_used_fallback, Some(false));
     }
 }

--- a/src-tauri/src/recording/session/lifecycle.rs
+++ b/src-tauri/src/recording/session/lifecycle.rs
@@ -1,11 +1,15 @@
 use crate::recording::audio::{start_capture, write_wav_file};
 use crate::recording::compression::{run_post_transcription_compression, SessionAudioCompressedEvent};
-use crate::recording::models::Session;
+use crate::recording::models::{AppConfig, Session};
 use crate::recording::session::storage::add_session;
 use crate::recording::state::{RecordingStatus, SharedRecordingState};
-use crate::recording::transcription::transcribe_with_whisper;
+use crate::recording::transcription::{
+    transcribe_in_chunks, transcribe_with_whisper, ChunkingTelemetry,
+};
 use crate::recording::utils::{copy_to_clipboard, get_storage_dir};
 use chrono::Utc;
+use std::path::Path;
+use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
@@ -137,6 +141,9 @@ pub fn stop_recording(state: SharedRecordingState) -> Result<Session, String> {
         clipboard_copied: false,
         transcription_time_seconds: None,
         model_path: None,
+        chunking_analysis_seconds: None,
+        chunk_count: None,
+        chunking_used_fallback: None,
     };
 
     // Persist initial session to index
@@ -166,7 +173,7 @@ pub fn orchestrate_async_transcription<F>(
     audio_path: std::path::PathBuf,
     event_emitter: F,
 ) where
-    F: Fn(TranscriptionResult) + Send + 'static,
+    F: Fn(TranscriptionResult) + Send + Sync + 'static,
 {
     // Mark the session as in-flight for transcription before the worker thread
     // starts so the batch-compression worker won't race it.
@@ -175,7 +182,21 @@ pub fn orchestrate_async_transcription<F>(
     }
 
     thread::spawn(move || {
-        let result = process_transcription_async(audio_path, session_id.clone());
+        // Arc the emitter so the progress callback (which fires repeatedly
+        // during chunked transcription) can share it with the success/error
+        // call paths.
+        let emitter = Arc::new(event_emitter);
+        let progress_session_id = session_id.clone();
+        let progress_emitter = Arc::clone(&emitter);
+        let progress_fn = move |current: u32, total: u32| {
+            progress_emitter(TranscriptionResult::Progress(ChunkProgressEvent {
+                session_id: progress_session_id.clone(),
+                current,
+                total,
+            }));
+        };
+
+        let result = process_transcription_async(audio_path, session_id.clone(), &progress_fn);
 
         // Update state to idle regardless of success/failure
         if let Ok(mut state_guard) = state.lock() {
@@ -188,7 +209,7 @@ pub fn orchestrate_async_transcription<F>(
             Ok(session) => {
                 let audio_path_for_compression = session.audio_path.clone();
                 let session_id_for_compression = session.id.clone();
-                event_emitter(TranscriptionResult::Success(session));
+                emitter(TranscriptionResult::Success(session));
 
                 // Best-effort post-transcription compression. Runs on this same
                 // background thread after the success event has already fired
@@ -199,7 +220,7 @@ pub fn orchestrate_async_transcription<F>(
                     &audio_path_for_compression,
                 ) {
                     Ok(Some(compression_event)) => {
-                        event_emitter(TranscriptionResult::Compressed(compression_event));
+                        emitter(TranscriptionResult::Compressed(compression_event));
                     }
                     Ok(None) => {
                         // Compression disabled — nothing to do.
@@ -214,7 +235,7 @@ pub fn orchestrate_async_transcription<F>(
                     }
                 }
             }
-            Err(error) => event_emitter(TranscriptionResult::Error {
+            Err(error) => emitter(TranscriptionResult::Error {
                 session_id,
                 error,
             }),
@@ -222,9 +243,18 @@ pub fn orchestrate_async_transcription<F>(
     });
 }
 
+/// Per-chunk progress for a chunked transcription. `current` is 1-indexed.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChunkProgressEvent {
+    pub session_id: String,
+    pub current: u32,
+    pub total: u32,
+}
+
 /// Result of async transcription for event emission
 pub enum TranscriptionResult {
     Success(Session),
+    Progress(ChunkProgressEvent),
     Compressed(SessionAudioCompressedEvent),
     Error { session_id: String, error: String },
 }
@@ -232,19 +262,23 @@ pub enum TranscriptionResult {
 /// Process transcription asynchronously and update session
 ///
 /// This is the second phase of the stop workflow:
-/// 1. Transcribes audio (if configured)
+/// 1. Transcribes audio (if configured) — routes through the chunked path
+///    when the recording is long enough and chunking is enabled
 /// 2. Copies transcript to clipboard (if successful)
-/// 3. Updates session record with transcription results
-/// 4. Records transcription timing statistics for future estimates
+/// 3. Updates session record with transcription + chunking telemetry
+///
+/// `on_progress(current, total)` fires per chunk on the chunked path. The
+/// single-shot path does not emit progress (the UI falls back to its
+/// time-based estimate).
 ///
 /// Returns updated session on success, or error message on failure
 pub fn process_transcription_async(
     audio_path: std::path::PathBuf,
     session_id: String,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
 ) -> Result<Session, String> {
     use crate::recording::session::storage::{load_sessions, save_sessions};
 
-    // Load sessions to get audio duration before transcription
     let mut index = load_sessions()?;
     let audio_duration = index
         .sessions
@@ -253,21 +287,23 @@ pub fn process_transcription_async(
         .map(|s| s.duration)
         .unwrap_or(0.0);
 
-    // Time the transcription process
+    // Single config load: drives both the route decision (chunking vs
+    // single-shot) and the model-path telemetry the estimator needs.
+    let config = crate::recording::load_config().ok();
+
     let transcription_start = Instant::now();
-
-    // Attempt transcription
-    let (transcript_path, preview, clipboard_copied) =
-        process_transcription(&audio_path, &session_id);
-
+    let (transcript_path, preview, clipboard_copied, chunking_telemetry) =
+        run_transcription_route(
+            &audio_path,
+            &session_id,
+            audio_duration,
+            config.as_ref(),
+            on_progress,
+        );
     let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
 
-    // Get model path for tracking
-    let model_path = crate::recording::load_config()
-        .ok()
-        .map(|config| config.model_path);
+    let model_path = config.as_ref().map(|c| c.model_path.clone());
 
-    // Find and update the session
     let updated_session = {
         let session = index
             .sessions
@@ -279,19 +315,96 @@ pub fn process_transcription_async(
         session.preview = preview;
         session.clipboard_copied = clipboard_copied;
 
-        // Store transcription metadata for progress estimation
         if !transcript_path.is_empty() && audio_duration > 0.0 {
             session.transcription_time_seconds = Some(transcription_elapsed);
             session.model_path = model_path;
+        }
+        if let Some(telemetry) = chunking_telemetry {
+            session.chunking_analysis_seconds = Some(telemetry.analysis_seconds);
+            session.chunk_count = Some(telemetry.chunk_count);
+            session.chunking_used_fallback = Some(telemetry.used_fallback);
         }
 
         session.clone()
     };
 
-    // Save updated sessions
     save_sessions(&index)?;
 
     Ok(updated_session)
+}
+
+/// Decide between the chunked and single-shot transcription paths and run
+/// the chosen one. Returns the same shape the legacy single-shot path
+/// produced, plus optional chunking telemetry to persist on the session.
+///
+/// Chunking is silently disabled when FFmpeg is missing or unconfigured —
+/// the user shouldn't get a transcription failure just because chunking
+/// can't run. The path falls back to a normal single-shot transcription
+/// in that case (PRD edge case 7).
+fn run_transcription_route(
+    audio_path: &Path,
+    session_id: &str,
+    audio_duration_sec: f64,
+    config: Option<&AppConfig>,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> (String, String, bool, Option<ChunkingTelemetry>) {
+    if let Some(cfg) = config {
+        if should_use_chunking(cfg, audio_duration_sec) {
+            return run_chunked_path(audio_path, session_id, audio_duration_sec, cfg, on_progress);
+        }
+    }
+
+    let (path, preview, copied) = process_transcription(audio_path, session_id);
+    (path, preview, copied, None)
+}
+
+fn should_use_chunking(config: &AppConfig, audio_duration_sec: f64) -> bool {
+    if !config.audio_chunking.enabled {
+        return false;
+    }
+    let ffmpeg = config.ffmpeg_path.trim();
+    if ffmpeg.is_empty() {
+        return false;
+    }
+    if !Path::new(ffmpeg).exists() {
+        log::warn!("Chunking enabled but FFmpeg not found at '{}' — running single-shot transcription instead", ffmpeg);
+        return false;
+    }
+    audio_duration_sec > config.audio_chunking.min_chunk_duration_sec
+}
+
+fn run_chunked_path(
+    audio_path: &Path,
+    session_id: &str,
+    audio_duration_sec: f64,
+    config: &AppConfig,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> (String, String, bool, Option<ChunkingTelemetry>) {
+    match transcribe_in_chunks(audio_path, session_id, audio_duration_sec, config, on_progress) {
+        Ok(outcome) => {
+            let preview = generate_preview(&outcome.transcript_text);
+            let clipboard_copied = if !outcome.transcript_text.is_empty() {
+                copy_to_clipboard(&outcome.transcript_text).is_ok()
+            } else {
+                false
+            };
+            (
+                outcome.transcript_path,
+                preview,
+                clipboard_copied,
+                Some(outcome.telemetry),
+            )
+        }
+        Err(e) => {
+            log::error!("Chunked transcription failed: {}", e);
+            (
+                String::new(),
+                format!("Transcription failed: {}", e),
+                false,
+                None,
+            )
+        }
+    }
 }
 
 /// Calculate recording duration from start time, excluding paused time
@@ -399,30 +512,45 @@ pub fn retranscribe_session(session_id: &str) -> Result<String, String> {
     // Get audio duration for metadata
     let audio_duration = session.duration;
 
-    // Time the transcription process
+    let config = crate::recording::load_config().ok();
+    let no_op_progress: &(dyn Fn(u32, u32) + Sync) = &|_, _| {};
+
     let transcription_start = Instant::now();
-
-    // Run transcription
-    let (transcript_path, transcript_text) = transcribe_with_whisper(&audio_path, session_id)?;
-
+    let (transcript_path, preview, _clipboard_copied, chunking_telemetry) =
+        run_transcription_route(
+            &audio_path,
+            session_id,
+            audio_duration,
+            config.as_ref(),
+            no_op_progress,
+        );
     let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
 
-    // Get model path for tracking
-    let model_path = crate::recording::load_config()
-        .ok()
-        .map(|config| config.model_path);
+    // Reload transcript text from disk so the return matches the saved file
+    // exactly (whether single-shot or stitched-chunk output).
+    let transcript_text = if transcript_path.is_empty() {
+        return Err(preview);
+    } else {
+        let abs_transcript = storage_dir.join(&transcript_path);
+        std::fs::read_to_string(&abs_transcript)
+            .map_err(|e| format!("Failed to read regenerated transcript: {}", e))?
+    };
 
-    // Update session with new transcript info
+    let model_path = config.as_ref().map(|c| c.model_path.clone());
+
     session.transcript_path = transcript_path.clone();
-    session.preview = generate_preview(&transcript_text);
+    session.preview = preview;
 
-    // Store transcription metadata for progress estimation
     if !transcript_path.is_empty() && audio_duration > 0.0 {
         session.transcription_time_seconds = Some(transcription_elapsed);
         session.model_path = model_path;
     }
+    if let Some(telemetry) = chunking_telemetry {
+        session.chunking_analysis_seconds = Some(telemetry.analysis_seconds);
+        session.chunk_count = Some(telemetry.chunk_count);
+        session.chunking_used_fallback = Some(telemetry.used_fallback);
+    }
 
-    // Save updated sessions
     save_sessions(&index)?;
 
     Ok(transcript_text)

--- a/src-tauri/src/recording/session/storage.rs
+++ b/src-tauri/src/recording/session/storage.rs
@@ -99,6 +99,9 @@ mod tests {
             clipboard_copied: false,
             transcription_time_seconds: None,
             model_path: None,
+            chunking_analysis_seconds: None,
+            chunk_count: None,
+            chunking_used_fallback: None,
         }
     }
 
@@ -211,6 +214,9 @@ mod tests {
             clipboard_copied: true,
             transcription_time_seconds: Some(18.5),
             model_path: Some("/path/to/model.bin".to_string()),
+            chunking_analysis_seconds: None,
+            chunk_count: None,
+            chunking_used_fallback: None,
         };
 
         let json = serde_json::to_string(&session).unwrap();

--- a/src-tauri/src/recording/transcription/chunked_orchestrator.rs
+++ b/src-tauri/src/recording/transcription/chunked_orchestrator.rs
@@ -1,0 +1,214 @@
+//! Drives the chunked transcription path: silence-detect + split → per-chunk
+//! Whisper → stitch → write the final transcript. Emits per-chunk progress so
+//! the UI can show "chunk 2 of 3" while the long-running Whisper passes run.
+
+use crate::recording::chunking::{plan_and_split, ChunkingError};
+use crate::recording::models::AppConfig;
+use crate::recording::transcription::engine::transcribe_audio_file;
+use crate::recording::transcription::text_processor::save_transcript;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Telemetry collected during the chunking run. Persisted on the `Session`
+/// so the Settings panel can report overhead averages.
+#[derive(Debug, Clone)]
+pub struct ChunkingTelemetry {
+    pub analysis_seconds: f64,
+    pub chunk_count: u32,
+    pub used_fallback: bool,
+}
+
+/// Outcome of a chunked transcription: same shape as the single-shot path
+/// plus telemetry the caller persists on the session.
+#[derive(Debug)]
+pub struct ChunkedTranscriptionOutcome {
+    pub transcript_path: String,
+    pub transcript_text: String,
+    pub telemetry: ChunkingTelemetry,
+}
+
+/// Run the chunked transcription pipeline end-to-end.
+///
+/// `on_progress(current, total)` is invoked once per chunk *before* that
+/// chunk's Whisper pass starts, so the UI updates as soon as the chunk is
+/// in flight rather than after it lands.
+pub fn transcribe_in_chunks(
+    audio_path: &Path,
+    session_id: &str,
+    audio_duration_sec: f64,
+    config: &AppConfig,
+    on_progress: impl Fn(u32, u32),
+) -> Result<ChunkedTranscriptionOutcome, String> {
+    let chunk_dir = make_chunk_workspace(audio_path, session_id)
+        .map_err(|e| format!("Failed to prepare chunking workspace: {}", e))?;
+
+    let result = run_chunked_transcription(
+        audio_path,
+        session_id,
+        audio_duration_sec,
+        config,
+        &chunk_dir,
+        on_progress,
+    );
+
+    // Always attempt cleanup, even on failure. Best-effort: a stranded temp
+    // directory is harmless; we don't want a cleanup error to mask the real
+    // transcription error.
+    let _ = fs::remove_dir_all(&chunk_dir);
+
+    result
+}
+
+/// Create a temp directory adjacent to the source WAV. Co-locating with the
+/// audio file keeps the per-chunk FFmpeg writes on the same volume so they
+/// don't trigger cross-drive copies on Windows.
+fn make_chunk_workspace(audio_path: &Path, session_id: &str) -> std::io::Result<PathBuf> {
+    let parent = audio_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let chunk_dir = parent.join(format!(".chunks-{}", session_id));
+    if chunk_dir.exists() {
+        // Stale workspace from a crashed run — clear it.
+        let _ = fs::remove_dir_all(&chunk_dir);
+    }
+    fs::create_dir_all(&chunk_dir)?;
+    Ok(chunk_dir)
+}
+
+fn run_chunked_transcription(
+    audio_path: &Path,
+    session_id: &str,
+    audio_duration_sec: f64,
+    config: &AppConfig,
+    chunk_dir: &Path,
+    on_progress: impl Fn(u32, u32),
+) -> Result<ChunkedTranscriptionOutcome, String> {
+    let outcome = plan_and_split(
+        &config.ffmpeg_path,
+        audio_path,
+        audio_duration_sec,
+        &config.audio_chunking,
+        chunk_dir,
+    )
+    .map_err(map_chunking_error)?;
+
+    let chunk_count = outcome.chunk_files.len() as u32;
+    if chunk_count == 0 {
+        return Err("Chunking pipeline produced zero chunks for a non-empty recording".to_string());
+    }
+
+    let mut chunk_texts: Vec<String> = Vec::with_capacity(outcome.chunk_files.len());
+    for (idx, chunk_path) in outcome.chunk_files.iter().enumerate() {
+        on_progress((idx as u32) + 1, chunk_count);
+        let text = transcribe_audio_file(chunk_path)?;
+        chunk_texts.push(text);
+    }
+
+    let stitched = stitch_chunks(&chunk_texts);
+    let transcript_path = save_transcript(session_id, &stitched)?;
+
+    Ok(ChunkedTranscriptionOutcome {
+        transcript_path,
+        transcript_text: stitched,
+        telemetry: ChunkingTelemetry {
+            analysis_seconds: outcome.analysis_seconds,
+            chunk_count,
+            used_fallback: outcome.used_fallback,
+        },
+    })
+}
+
+/// Join per-chunk transcripts into a single document. A blank line between
+/// chunks is intentional — it gives the reader a visual seam that maps to a
+/// natural pause without breaking sentence flow.
+fn stitch_chunks(chunk_texts: &[String]) -> String {
+    chunk_texts
+        .iter()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn map_chunking_error(err: ChunkingError) -> String {
+    match err {
+        ChunkingError::FfmpegMissing { message } => {
+            format!("Chunking aborted: FFmpeg unavailable ({})", message)
+        }
+        ChunkingError::FfmpegFailed { message } => format!("Chunking aborted: {}", message),
+        ChunkingError::Io { message } => format!("Chunking aborted: I/O error ({})", message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stitch_joins_chunks_with_blank_line() {
+        let chunks = vec![
+            "First chunk text.".to_string(),
+            "Second chunk text.".to_string(),
+            "Third chunk text.".to_string(),
+        ];
+        let stitched = stitch_chunks(&chunks);
+        assert_eq!(
+            stitched,
+            "First chunk text.\n\nSecond chunk text.\n\nThird chunk text."
+        );
+    }
+
+    #[test]
+    fn test_stitch_trims_per_chunk_whitespace() {
+        let chunks = vec![
+            "  leading and trailing whitespace  \n".to_string(),
+            "\n\nanother\n".to_string(),
+        ];
+        let stitched = stitch_chunks(&chunks);
+        assert_eq!(stitched, "leading and trailing whitespace\n\nanother");
+    }
+
+    #[test]
+    fn test_stitch_drops_empty_chunks() {
+        let chunks = vec!["real text".to_string(), "".to_string(), "more text".to_string()];
+        let stitched = stitch_chunks(&chunks);
+        assert_eq!(stitched, "real text\n\nmore text");
+    }
+
+    #[test]
+    fn test_stitch_single_chunk() {
+        let chunks = vec!["just one".to_string()];
+        assert_eq!(stitch_chunks(&chunks), "just one");
+    }
+
+    #[test]
+    fn test_stitch_no_chunks_returns_empty() {
+        let chunks: Vec<String> = vec![];
+        assert_eq!(stitch_chunks(&chunks), "");
+    }
+
+    #[test]
+    fn test_map_chunking_error_distinguishes_variants_in_message() {
+        // The orchestrator collapses ChunkingError to String for the legacy
+        // API — keep the variant tag in the message so logs are diagnosable.
+        let missing = map_chunking_error(ChunkingError::FfmpegMissing {
+            message: "no binary".to_string(),
+        });
+        assert!(missing.contains("FFmpeg unavailable"));
+        assert!(missing.contains("no binary"));
+
+        let failed = map_chunking_error(ChunkingError::FfmpegFailed {
+            message: "exit 1".to_string(),
+        });
+        assert!(failed.starts_with("Chunking aborted:"));
+        assert!(failed.contains("exit 1"));
+        assert!(!failed.contains("FFmpeg unavailable"));
+
+        let io = map_chunking_error(ChunkingError::Io {
+            message: "disk full".to_string(),
+        });
+        assert!(io.contains("I/O error"));
+        assert!(io.contains("disk full"));
+    }
+}

--- a/src-tauri/src/recording/transcription/engine.rs
+++ b/src-tauri/src/recording/transcription/engine.rs
@@ -1,5 +1,6 @@
 use crate::recording::config::load_config;
 use crate::recording::transcription::text_processor::{clean_transcript, save_transcript};
+use crate::recording::utils::apply_no_console_window;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -43,6 +44,26 @@ pub fn transcribe_with_whisper(
     Ok((transcript_path, cleaned_transcript))
 }
 
+/// Transcribe a single audio file without writing a session-scoped transcript.
+///
+/// Used by the chunked-transcription path, which calls this once per chunk and
+/// concatenates the returned text itself. The caller is responsible for any
+/// session-scoped persistence — this entry-point only runs Whisper, reads the
+/// raw output, cleans it, and removes Whisper's intermediate `.txt` file.
+pub fn transcribe_audio_file(audio_path: &Path) -> Result<String, String> {
+    let config = load_config()?;
+    validate_whisper_setup(&config)?;
+
+    let whisper_output_path = run_whisper_process(audio_path, &config)?;
+
+    let raw_transcript = fs::read_to_string(&whisper_output_path)
+        .map_err(|e| format!("Failed to read transcript file: {}", e))?;
+
+    let _ = fs::remove_file(whisper_output_path);
+
+    Ok(clean_transcript(&raw_transcript))
+}
+
 /// Validate that Whisper.cpp and model files exist
 fn validate_whisper_setup(
     config: &crate::recording::models::WhisperConfig,
@@ -64,6 +85,28 @@ fn validate_whisper_setup(
     Ok(())
 }
 
+/// Build the Whisper.cpp `Command` used for both single-file and chunked
+/// transcription. On Windows the `CREATE_NO_WINDOW` flag is applied so the
+/// console popup never flashes during a recording.
+///
+/// Extracted so the chunked path can run Whisper once per chunk through a
+/// single construction site rather than re-inlining the args list.
+fn build_whisper_command(
+    whisper_path: &str,
+    model_path: &str,
+    audio_path: &Path,
+) -> Command {
+    let mut cmd = Command::new(whisper_path);
+    cmd.arg("-m")
+        .arg(model_path)
+        .arg("-f")
+        .arg(audio_path)
+        .arg("-otxt");
+
+    apply_no_console_window(&mut cmd);
+    cmd
+}
+
 /// Execute Whisper.cpp process and return the output file path
 ///
 /// On Windows, hides the console window to prevent popups
@@ -73,32 +116,7 @@ fn run_whisper_process(
 ) -> Result<std::path::PathBuf, String> {
     // Run Whisper.cpp with -otxt flag to generate transcript file
     // Whisper will create a file named {audio_path}.txt
-    #[cfg(target_os = "windows")]
-    let output = {
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
-
-        Command::new(&config.whisper_path)
-            .arg("-m")
-            .arg(&config.model_path)
-            .arg("-f")
-            .arg(audio_path)
-            .arg("-otxt")
-            .creation_flags(CREATE_NO_WINDOW)
-            .output()
-            .map_err(|_| {
-                "Transcription service couldn't start. Check your Whisper.cpp installation."
-                    .to_string()
-            })?
-    };
-
-    #[cfg(not(target_os = "windows"))]
-    let output = Command::new(&config.whisper_path)
-        .arg("-m")
-        .arg(&config.model_path)
-        .arg("-f")
-        .arg(audio_path)
-        .arg("-otxt")
+    let output = build_whisper_command(&config.whisper_path, &config.model_path, audio_path)
         .output()
         .map_err(|_| {
             "Transcription service couldn't start. Check your Whisper.cpp installation.".to_string()
@@ -123,4 +141,49 @@ fn run_whisper_process(
     }
 
     Ok(whisper_output_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_build_whisper_command_contains_required_args() {
+        let audio = PathBuf::from("/tmp/recording.wav");
+        let cmd = build_whisper_command("/usr/bin/whisper", "/models/base.bin", &audio);
+
+        let args: Vec<&str> = cmd
+            .get_args()
+            .map(|s| s.to_str().unwrap_or(""))
+            .collect();
+
+        assert!(args.contains(&"-m"), "missing -m flag, got args: {:?}", args);
+        assert!(args.contains(&"-f"), "missing -f flag, got args: {:?}", args);
+        assert!(args.contains(&"-otxt"), "missing -otxt flag, got args: {:?}", args);
+    }
+
+    #[test]
+    fn test_build_whisper_command_uses_configured_paths() {
+        let audio = PathBuf::from("/tmp/recording.wav");
+        let cmd = build_whisper_command("/custom/whisper", "/custom/model.bin", &audio);
+
+        // Program is the whisper binary path
+        assert_eq!(
+            cmd.get_program().to_str().unwrap(),
+            "/custom/whisper"
+        );
+
+        // Model path appears as the value after -m, audio path after -f
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        let m_idx = args.iter().position(|a| a == "-m").expect("no -m");
+        assert_eq!(args[m_idx + 1], "/custom/model.bin");
+
+        let f_idx = args.iter().position(|a| a == "-f").expect("no -f");
+        assert_eq!(args[f_idx + 1], audio.to_string_lossy());
+    }
 }

--- a/src-tauri/src/recording/transcription/mod.rs
+++ b/src-tauri/src/recording/transcription/mod.rs
@@ -1,4 +1,6 @@
-pub mod text_processor;
+pub mod chunked_orchestrator;
 pub mod engine;
+pub mod text_processor;
 
+pub use chunked_orchestrator::{transcribe_in_chunks, ChunkingTelemetry};
 pub use engine::transcribe_with_whisper;

--- a/src-tauri/src/recording/utils/mod.rs
+++ b/src-tauri/src/recording/utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod clipboard;
 pub mod storage;
+pub mod subprocess;
 
 pub use clipboard::copy_to_clipboard;
 pub use storage::get_storage_dir;
+pub use subprocess::apply_no_console_window;

--- a/src-tauri/src/recording/utils/subprocess.rs
+++ b/src-tauri/src/recording/utils/subprocess.rs
@@ -1,0 +1,46 @@
+//! Cross-platform helpers for spawning native subprocesses.
+//!
+//! On Windows the default `Command` spawn flashes a console window for every
+//! subprocess we shell out to (FFmpeg, Whisper.cpp). The same `CREATE_NO_WINDOW`
+//! incantation was being repeated at every spawn site — this helper centralizes
+//! it so a new spawn site can't forget to apply it.
+
+use std::process::Command;
+
+/// Apply the `CREATE_NO_WINDOW` creation flag on Windows so the child process
+/// doesn't pop up a console window during a recording. No-op on other
+/// platforms.
+///
+/// Returns the command for fluent-style chaining at the call site.
+pub fn apply_no_console_window(cmd: &mut Command) -> &mut Command {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        // Documented Win32 process-creation flag — keeps the child detached
+        // from any console so a console window is never created or attached.
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Suppress unused-variable warning on non-Windows without a `_` rename.
+        let _ = cmd;
+    }
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_no_console_window_is_chainable_and_safe() {
+        // The helper must be safe to call on every platform and return the
+        // same command so call sites can keep using the builder style.
+        let mut cmd = Command::new("echo");
+        let ptr_before = &cmd as *const Command;
+        let result = apply_no_console_window(&mut cmd);
+        let ptr_after = result as *const Command;
+        assert_eq!(ptr_before, ptr_after, "must return the same command ref");
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "ThoughtCast",
-  "version": "0.1.0",
+  "version": "0.2.7-0",
   "identifier": "com.thoughtcast.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -32,6 +32,11 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
+    ],
+    "resources": [
+      "resources/sounds/start.wav",
+      "resources/sounds/stop.wav",
+      "resources/sounds/ready.wav"
     ],
     "macOS": {
       "infoPlist": "Info.plist",

--- a/src/api/Session.ts
+++ b/src/api/Session.ts
@@ -16,6 +16,12 @@ export interface Session {
   transcript_path?: string;
   /** Whether the transcript was automatically copied to clipboard */
   clipboard_copied?: boolean;
+  /** Wall-clock seconds spent on silence-detect + split. Absent for unchunked recordings. */
+  chunking_analysis_seconds?: number;
+  /** Number of chunks the recording was split into. Absent when chunking did not run. */
+  chunk_count?: number;
+  /** True when the planner had to fall back to a hard cut (no silence in window). */
+  chunking_used_fallback?: boolean;
 }
 
 /**

--- a/src/api/TranscriptionEvents.ts
+++ b/src/api/TranscriptionEvents.ts
@@ -14,3 +14,16 @@ export interface TranscriptionErrorEvent {
   session_id: string;
   error: string;
 }
+
+/**
+ * Per-chunk progress for a chunked transcription. Emitted once per chunk
+ * just before that chunk's Whisper pass starts. `current` is 1-indexed.
+ *
+ * Single-shot recordings never emit this event — the UI falls back to its
+ * time-based progress estimate.
+ */
+export interface TranscriptionProgressEvent {
+  session_id: string;
+  current: number;
+  total: number;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -4,6 +4,7 @@ export type { RecordingStatus } from './RecordingStatus';
 export type {
   TranscriptionCompleteEvent,
   TranscriptionErrorEvent,
+  TranscriptionProgressEvent,
 } from './TranscriptionEvents';
 export {
   SESSION_AUDIO_COMPRESSED,
@@ -18,6 +19,7 @@ export type {
 export type {
   TranscriptionEstimate,
   TranscriptionProgress,
+  ChunkProgressInfo,
 } from '../features/sessions/types';
 export { ApiError } from './ApiError';
 

--- a/src/features/recording/RecordingControls.css
+++ b/src/features/recording/RecordingControls.css
@@ -64,6 +64,13 @@
   background-color: transparent;
 }
 
+.estimate-chunk-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  letter-spacing: 0.01em;
+}
+
 .estimate-text {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);

--- a/src/features/recording/RecordingControls.tsx
+++ b/src/features/recording/RecordingControls.tsx
@@ -47,7 +47,12 @@ export default function RecordingControls({
       <div className="recording-controls">
         {displayData.shouldDisplay && (
           <div className="transcription-estimate">
-            <div className="estimate-text">Estimated: {displayData.estimatedText}</div>
+            {displayData.chunkLabel && (
+              <div className="estimate-chunk-label">{displayData.chunkLabel}</div>
+            )}
+            {displayData.estimatedText && (
+              <div className="estimate-text">Estimated: {displayData.estimatedText}</div>
+            )}
             {displayData.remainingText && (
               <div className="estimate-remaining">{displayData.remainingText}</div>
             )}

--- a/src/features/sessions/SessionViewer.tsx
+++ b/src/features/sessions/SessionViewer.tsx
@@ -170,7 +170,13 @@ export default function SessionViewer({
                     {displayData.shouldDisplay ? (
                       <>
                         <span>
-                          Transcribing... {displayData.estimatedText} estimated
+                          Transcribing...
+                          {displayData.chunkLabel && (
+                            <> {displayData.chunkLabel}</>
+                          )}
+                          {displayData.estimatedText && (
+                            <> {displayData.estimatedText} estimated</>
+                          )}
                         </span>
                         {displayData.remainingText && (
                           <span className="remaining-estimate">

--- a/src/features/sessions/types.ts
+++ b/src/features/sessions/types.ts
@@ -16,6 +16,12 @@ export interface Session {
   transcript_path?: string;
   /** Whether the transcript was automatically copied to clipboard */
   clipboard_copied?: boolean;
+  /** Wall-clock seconds spent on silence-detect + split. Absent for unchunked recordings. */
+  chunking_analysis_seconds?: number;
+  /** Number of chunks the recording was split into. Absent when chunking did not run. */
+  chunk_count?: number;
+  /** True when the planner had to fall back to a hard cut (no silence in window). */
+  chunking_used_fallback?: boolean;
 }
 
 /**
@@ -53,6 +59,17 @@ export interface TranscriptionEstimate {
 }
 
 /**
+ * Per-chunk position when a chunked transcription is in flight. `null` when
+ * the recording is unchunked (no `transcription-progress` event received).
+ */
+export interface ChunkProgressInfo {
+  /** 1-indexed chunk currently being transcribed. */
+  current: number;
+  /** Total chunks in the plan. */
+  total: number;
+}
+
+/**
  * Progress data for ongoing transcription
  */
 export interface TranscriptionProgress {
@@ -66,4 +83,6 @@ export interface TranscriptionProgress {
   hasEstimate: boolean;
   /** Remaining seconds (estimated - elapsed) */
   remainingSeconds: number | null;
+  /** Chunk position when chunked transcription is active, else null. */
+  chunkInfo: ChunkProgressInfo | null;
 }

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "../../shared/components";
 import { useSettingsForm } from "./useSettingsForm";
 import TranscriptionSettingsSection from "./sections/TranscriptionSettingsSection";
+import AudioChunkingSection from "./sections/audio-chunking/AudioChunkingSection";
 import CompressionSettingsSection from "./sections/CompressionSettingsSection";
 import KeyboardShortcutsSection from "./sections/KeyboardShortcutsSection";
 import AudioFeedbackSection from "./sections/AudioFeedbackSection";
@@ -228,6 +229,11 @@ function ActiveTabContent({
         />
       );
     case "transcription":
-      return <TranscriptionSettingsSection form={form} />;
+      return (
+        <>
+          <TranscriptionSettingsSection form={form} />
+          <AudioChunkingSection form={form} />
+        </>
+      );
   }
 }

--- a/src/features/settings/appConfig.ts
+++ b/src/features/settings/appConfig.ts
@@ -41,6 +41,21 @@ export interface AudioFeedbackConfig {
   readyCuePath: string;
 }
 
+/**
+ * Silence-detect-based chunking of long recordings before transcription.
+ * Mirrors the Rust `AudioChunkingConfig`. Units are SI (seconds, dB) so the
+ * fields can flow straight into FFmpeg's `silencedetect` filter without
+ * conversion.
+ */
+export interface AudioChunkingConfig {
+  enabled: boolean;
+  minChunkDurationSec: number;
+  maxChunkDurationSec: number;
+  /** Threshold in dB. Negative values are quieter than the threshold. */
+  silenceThresholdDb: number;
+  minSilenceDurationSec: number;
+}
+
 export interface AppConfig {
   whisperPath: string;
   modelPath: string;
@@ -49,6 +64,7 @@ export interface AppConfig {
   audioCompression: AudioCompressionConfig;
   keyboardShortcuts: KeyboardShortcutsConfig;
   audioFeedback: AudioFeedbackConfig;
+  audioChunking: AudioChunkingConfig;
 }
 
 export type PathKind = "executable" | "file" | "ffmpeg";
@@ -92,9 +108,24 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
     stopCuePath: "",
     readyCuePath: "",
   },
+  audioChunking: {
+    enabled: true,
+    minChunkDurationSec: 7 * 60,
+    maxChunkDurationSec: 10 * 60,
+    silenceThresholdDb: -35,
+    minSilenceDurationSec: 0.5,
+  },
 };
 
 export const COMPRESSION_AGE_OPTIONS: readonly number[] = [1, 7, 30];
+
+/** Bounds used by the chunking settings UI and draft validation. */
+export const CHUNKING_LIMITS = {
+  minChunkDurationSec: { min: 60, max: 1800 },
+  maxChunkDurationSec: { min: 60, max: 1800 },
+  silenceThresholdDb: { min: -80, max: -10 },
+  minSilenceDurationSec: { min: 0.1, max: 5 },
+} as const;
 
 /** Minimum push-to-talk hold (ms) below which we treat the event as a no-op. */
 export const PUSH_TO_TALK_MIN_HOLD_MS = 300;

--- a/src/features/settings/mergeConfigDefaults.ts
+++ b/src/features/settings/mergeConfigDefaults.ts
@@ -4,6 +4,7 @@ import {
   AudioCompressionConfig,
   AudioFeedbackConfig,
   KeyboardShortcutsConfig,
+  AudioChunkingConfig,
 } from "./appConfig";
 
 /**
@@ -28,6 +29,9 @@ export function mergeConfigDefaults(
   >;
   const feedbackPartial = (partial.audioFeedback ?? {}) as Partial<
     AudioFeedbackConfig
+  >;
+  const chunkingPartial = (partial.audioChunking ?? {}) as Partial<
+    AudioChunkingConfig
   >;
 
   return {
@@ -71,6 +75,22 @@ export function mergeConfigDefaults(
       readyCuePath:
         feedbackPartial.readyCuePath ??
         DEFAULT_APP_CONFIG.audioFeedback.readyCuePath,
+    },
+    audioChunking: {
+      enabled:
+        chunkingPartial.enabled ?? DEFAULT_APP_CONFIG.audioChunking.enabled,
+      minChunkDurationSec:
+        chunkingPartial.minChunkDurationSec ??
+        DEFAULT_APP_CONFIG.audioChunking.minChunkDurationSec,
+      maxChunkDurationSec:
+        chunkingPartial.maxChunkDurationSec ??
+        DEFAULT_APP_CONFIG.audioChunking.maxChunkDurationSec,
+      silenceThresholdDb:
+        chunkingPartial.silenceThresholdDb ??
+        DEFAULT_APP_CONFIG.audioChunking.silenceThresholdDb,
+      minSilenceDurationSec:
+        chunkingPartial.minSilenceDurationSec ??
+        DEFAULT_APP_CONFIG.audioChunking.minSilenceDurationSec,
     },
   };
 }

--- a/src/features/settings/sections/audio-chunking/AudioChunkingSection.css
+++ b/src/features/settings/sections/audio-chunking/AudioChunkingSection.css
@@ -1,0 +1,133 @@
+.chunking-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-xs) 0;
+  font-size: var(--font-size-base);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.chunking-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.chunking-fieldset {
+  border: none;
+  padding: 0;
+  margin: var(--space-sm) 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.chunking-fieldset[disabled] {
+  opacity: 0.55;
+}
+
+.chunking-fieldset[disabled] input[type="number"] {
+  cursor: not-allowed;
+}
+
+.chunking-subheading {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  margin: var(--space-sm) 0 var(--space-xs) 0;
+}
+
+.chunking-subheading:first-child {
+  margin-top: 0;
+}
+
+.chunking-field-row {
+  display: flex;
+  gap: var(--space-xl);
+  align-items: center;
+  padding-left: var(--space-2xl);
+}
+
+.chunking-field {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+}
+
+.chunking-field > span:first-child {
+  min-width: 96px;
+  color: var(--color-text-secondary);
+}
+
+.chunking-field input[type="number"] {
+  width: 72px;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Suppress browser spinner jank — keyboard + drag still work via min/max/step. */
+.chunking-field input[type="number"]::-webkit-outer-spin-button,
+.chunking-field input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.chunking-field input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+.chunking-field input[type="number"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.chunking-field-suffix {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  min-width: 24px;
+}
+
+.chunking-field-error {
+  margin: var(--space-xs) 0 0 var(--space-2xl);
+  font-size: var(--font-size-xs);
+  color: var(--color-danger);
+}
+
+.chunking-overhead {
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.chunking-overhead-heading {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.chunking-overhead-row {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.chunking-overhead-empty {
+  font-style: italic;
+  color: var(--color-text-tertiary);
+}

--- a/src/features/settings/sections/audio-chunking/AudioChunkingSection.tsx
+++ b/src/features/settings/sections/audio-chunking/AudioChunkingSection.tsx
@@ -1,0 +1,177 @@
+import SettingsSection from "../SettingsSection";
+import type { useSettingsForm } from "../../useSettingsForm";
+import { CHUNKING_LIMITS } from "../../appConfig";
+import { useChunkingOverheadSummary } from "./useChunkingOverheadSummary";
+import { minutesToChunkSeconds } from "./minutesToChunkSeconds";
+import { formatHumanReadableDuration } from "../../../transcription/formatHumanReadableDuration";
+import "./AudioChunkingSection.css";
+
+type FormHandle = ReturnType<typeof useSettingsForm>;
+
+interface AudioChunkingSectionProps {
+  form: FormHandle;
+}
+
+/**
+ * Settings → Audio Chunking section (rendered under the Transcription tab).
+ *
+ * Hosts the master toggle, target chunk-window inputs (min/max minutes),
+ * silence-detect threshold and minimum-silence-duration controls, plus a
+ * read-only "Recent performance" block summarizing chunking overhead so the
+ * user can judge whether the feature is worth keeping enabled.
+ */
+export default function AudioChunkingSection({
+  form,
+}: AudioChunkingSectionProps) {
+  const chunking = form.draft.audioChunking;
+  const overhead = useChunkingOverheadSummary();
+
+  const setMinutesField = (
+    field: "minChunkDurationSec" | "maxChunkDurationSec",
+    minutes: number
+  ) => {
+    const seconds = minutesToChunkSeconds(minutes);
+    if (seconds === null) return;
+    form.setChunkingField(field, seconds);
+  };
+
+  return (
+    <SettingsSection
+      title="Audio Chunking"
+      description="Split long recordings at silent pauses before transcribing — avoids repetition loops on long files. Recommended for recordings over 10 minutes."
+    >
+      <label className="chunking-toggle">
+        <input
+          type="checkbox"
+          checked={chunking.enabled}
+          onChange={(e) => form.setChunkingField("enabled", e.target.checked)}
+        />
+        <span>Enable chunking for long recordings</span>
+      </label>
+
+      <fieldset className="chunking-fieldset" disabled={!chunking.enabled}>
+        <div className="chunking-subheading">Target chunk length</div>
+        <div className="chunking-field-row">
+          <label className="chunking-field">
+            <span>Min</span>
+            <input
+              type="number"
+              min={CHUNKING_LIMITS.minChunkDurationSec.min / 60}
+              max={CHUNKING_LIMITS.minChunkDurationSec.max / 60}
+              step={1}
+              value={Math.round(chunking.minChunkDurationSec / 60)}
+              onChange={(e) =>
+                setMinutesField("minChunkDurationSec", Number(e.target.value))
+              }
+            />
+            <span className="chunking-field-suffix">min</span>
+          </label>
+          <label className="chunking-field">
+            <span>Max</span>
+            <input
+              type="number"
+              min={CHUNKING_LIMITS.maxChunkDurationSec.min / 60}
+              max={CHUNKING_LIMITS.maxChunkDurationSec.max / 60}
+              step={1}
+              value={Math.round(chunking.maxChunkDurationSec / 60)}
+              onChange={(e) =>
+                setMinutesField("maxChunkDurationSec", Number(e.target.value))
+              }
+            />
+            <span className="chunking-field-suffix">min</span>
+          </label>
+        </div>
+        {(form.fieldErrors.chunkingMinDuration ||
+          form.fieldErrors.chunkingMaxDuration ||
+          form.fieldErrors.chunkingMinMaxOrder) && (
+          <p className="chunking-field-error">
+            {form.fieldErrors.chunkingMinDuration ||
+              form.fieldErrors.chunkingMaxDuration ||
+              form.fieldErrors.chunkingMinMaxOrder}
+          </p>
+        )}
+
+        <div className="chunking-subheading">Silence detection</div>
+        <div className="chunking-field-row">
+          <label className="chunking-field">
+            <span>Threshold</span>
+            <input
+              type="number"
+              min={CHUNKING_LIMITS.silenceThresholdDb.min}
+              max={CHUNKING_LIMITS.silenceThresholdDb.max}
+              step={1}
+              value={chunking.silenceThresholdDb}
+              onChange={(e) =>
+                form.setChunkingField(
+                  "silenceThresholdDb",
+                  Number(e.target.value)
+                )
+              }
+            />
+            <span className="chunking-field-suffix">dB</span>
+          </label>
+          <label className="chunking-field">
+            <span>Min duration</span>
+            <input
+              type="number"
+              min={CHUNKING_LIMITS.minSilenceDurationSec.min}
+              max={CHUNKING_LIMITS.minSilenceDurationSec.max}
+              step={0.1}
+              value={chunking.minSilenceDurationSec}
+              onChange={(e) =>
+                form.setChunkingField(
+                  "minSilenceDurationSec",
+                  Number(e.target.value)
+                )
+              }
+            />
+            <span className="chunking-field-suffix">sec</span>
+          </label>
+        </div>
+        {(form.fieldErrors.chunkingSilenceThreshold ||
+          form.fieldErrors.chunkingMinSilenceDuration) && (
+          <p className="chunking-field-error">
+            {form.fieldErrors.chunkingSilenceThreshold ||
+              form.fieldErrors.chunkingMinSilenceDuration}
+          </p>
+        )}
+      </fieldset>
+
+      <ChunkingOverheadReadout overhead={overhead} />
+    </SettingsSection>
+  );
+}
+
+interface OverheadReadoutProps {
+  overhead: ReturnType<typeof useChunkingOverheadSummary>;
+}
+
+function ChunkingOverheadReadout({ overhead }: OverheadReadoutProps) {
+  if (overhead.sampleCount === 0) {
+    return (
+      <div className="chunking-overhead chunking-overhead-empty">
+        No chunked recordings yet — analysis overhead will appear here after
+        the first long recording.
+      </div>
+    );
+  }
+
+  const avgPerMinute = overhead.averageOverheadPerMinute ?? 0;
+  const longest = overhead.longestAnalysisSeconds ?? 0;
+  const longestAudio = overhead.longestAnalysisAudioSeconds ?? 0;
+
+  return (
+    <div className="chunking-overhead">
+      <div className="chunking-overhead-heading">Recent performance</div>
+      <div className="chunking-overhead-row">
+        Last {overhead.sampleCount} chunked{" "}
+        {overhead.sampleCount === 1 ? "recording" : "recordings"}: median{" "}
+        {avgPerMinute.toFixed(2)}s analysis per minute of audio.
+      </div>
+      <div className="chunking-overhead-row">
+        Longest analysis: {longest.toFixed(1)}s on a{" "}
+        {formatHumanReadableDuration(longestAudio)} recording.
+      </div>
+    </div>
+  );
+}

--- a/src/features/settings/sections/audio-chunking/calculateChunkingOverheadSummary.test.ts
+++ b/src/features/settings/sections/audio-chunking/calculateChunkingOverheadSummary.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { calculateChunkingOverheadSummary } from './calculateChunkingOverheadSummary';
+import { Session } from '../../../../api';
+
+function session(overrides: Partial<Session>): Session {
+  return {
+    id: 'test',
+    preview: 'preview',
+    timestamp: '2026-01-01T00:00:00Z',
+    audio_path: 'audio/test.wav',
+    duration: 600,
+    ...overrides,
+  };
+}
+
+describe('calculateChunkingOverheadSummary', () => {
+  it('returns null fields when no chunked sessions exist', () => {
+    const summary = calculateChunkingOverheadSummary([
+      session({ id: 'a' }),
+      session({ id: 'b', duration: 300 }),
+    ]);
+
+    expect(summary.averageOverheadPerMinute).toBe(null);
+    expect(summary.longestAnalysisSeconds).toBe(null);
+    expect(summary.longestAnalysisAudioSeconds).toBe(null);
+    expect(summary.sampleCount).toBe(0);
+  });
+
+  it('ignores sessions with missing analysis seconds', () => {
+    const summary = calculateChunkingOverheadSummary([
+      session({ id: 'a' }),
+      session({ id: 'b', chunking_analysis_seconds: 5, duration: 600 }),
+    ]);
+    expect(summary.sampleCount).toBe(1);
+  });
+
+  it('ignores sessions with zero duration to avoid division-by-zero', () => {
+    const summary = calculateChunkingOverheadSummary([
+      session({ id: 'a', chunking_analysis_seconds: 5, duration: 0 }),
+    ]);
+    expect(summary.averageOverheadPerMinute).toBe(null);
+    expect(summary.sampleCount).toBe(0);
+  });
+
+  it('computes overhead-per-minute as analysis / (duration / 60)', () => {
+    const summary = calculateChunkingOverheadSummary([
+      // 600s = 10 min, 3s analysis → 0.3s/min
+      session({ id: 'a', chunking_analysis_seconds: 3, duration: 600 }),
+    ]);
+    expect(summary.averageOverheadPerMinute).toBeCloseTo(0.3, 5);
+    expect(summary.sampleCount).toBe(1);
+  });
+
+  it('uses median across multiple sessions (not mean)', () => {
+    // Three sessions: ratios 0.1, 0.3, 5.0 — mean ~1.8, median 0.3.
+    const summary = calculateChunkingOverheadSummary([
+      session({ id: 'a', chunking_analysis_seconds: 1, duration: 600 }), // 0.1
+      session({ id: 'b', chunking_analysis_seconds: 3, duration: 600 }), // 0.3
+      session({ id: 'c', chunking_analysis_seconds: 50, duration: 600 }), // 5.0
+    ]);
+    expect(summary.averageOverheadPerMinute).toBeCloseTo(0.3, 5);
+  });
+
+  it('averages the two middle values for an even count', () => {
+    const summary = calculateChunkingOverheadSummary([
+      session({ id: 'a', chunking_analysis_seconds: 1, duration: 600 }), // 0.1
+      session({ id: 'b', chunking_analysis_seconds: 3, duration: 600 }), // 0.3
+    ]);
+    // Median of [0.1, 0.3] = 0.2
+    expect(summary.averageOverheadPerMinute).toBeCloseTo(0.2, 5);
+  });
+
+  it('reports the worst-case analysis pass and its audio length', () => {
+    const summary = calculateChunkingOverheadSummary([
+      session({ id: 'a', chunking_analysis_seconds: 2, duration: 600 }),
+      session({ id: 'b', chunking_analysis_seconds: 8.1, duration: 28 * 60 }),
+      session({ id: 'c', chunking_analysis_seconds: 4, duration: 1200 }),
+    ]);
+    expect(summary.longestAnalysisSeconds).toBe(8.1);
+    expect(summary.longestAnalysisAudioSeconds).toBe(28 * 60);
+  });
+});

--- a/src/features/settings/sections/audio-chunking/calculateChunkingOverheadSummary.ts
+++ b/src/features/settings/sections/audio-chunking/calculateChunkingOverheadSummary.ts
@@ -1,0 +1,85 @@
+import { Session } from '../../../../api';
+
+/**
+ * Summary of how much overhead chunking has historically added per minute
+ * of audio. Reported alongside the chunking toggle so the user can judge
+ * whether the feature is worth keeping enabled.
+ */
+export interface ChunkingOverheadSummary {
+  /**
+   * Median analysis seconds per minute of audio across chunked sessions.
+   * `null` when no chunked sessions exist yet.
+   */
+  averageOverheadPerMinute: number | null;
+  /** Longest single analysis pass observed (seconds), or null when no data. */
+  longestAnalysisSeconds: number | null;
+  /** Duration (seconds) of the recording behind `longestAnalysisSeconds`. */
+  longestAnalysisAudioSeconds: number | null;
+  /** How many sessions contributed to the summary. */
+  sampleCount: number;
+}
+
+const EMPTY_SUMMARY: ChunkingOverheadSummary = {
+  averageOverheadPerMinute: null,
+  longestAnalysisSeconds: null,
+  longestAnalysisAudioSeconds: null,
+  sampleCount: 0,
+};
+
+/**
+ * Reduce session history into a chunking-overhead summary.
+ *
+ * Filters sessions that ran chunking (have `chunking_analysis_seconds` set)
+ * and computes a median seconds-per-minute ratio plus the worst-case pass.
+ * Median (rather than mean) so a one-off cold-cache spike doesn't drag the
+ * displayed average up — same approach the transcription estimator uses.
+ *
+ * Pure: no I/O, no side effects, no formatting. Formatting and unit
+ * conversion live in the UI layer.
+ */
+export function calculateChunkingOverheadSummary(
+  sessions: readonly Session[]
+): ChunkingOverheadSummary {
+  const chunked = sessions.filter(
+    (s) =>
+      typeof s.chunking_analysis_seconds === 'number' &&
+      s.chunking_analysis_seconds > 0 &&
+      s.duration > 0
+  );
+
+  if (chunked.length === 0) {
+    return EMPTY_SUMMARY;
+  }
+
+  const overheadRatios = chunked.map(
+    (s) => (s.chunking_analysis_seconds as number) / (s.duration / 60)
+  );
+
+  const median = computeMedian(overheadRatios);
+
+  // Worst-case observed analysis pass.
+  let longest = chunked[0];
+  for (const session of chunked) {
+    if (
+      (session.chunking_analysis_seconds ?? 0) >
+      (longest.chunking_analysis_seconds ?? 0)
+    ) {
+      longest = session;
+    }
+  }
+
+  return {
+    averageOverheadPerMinute: median,
+    longestAnalysisSeconds: longest.chunking_analysis_seconds ?? null,
+    longestAnalysisAudioSeconds: longest.duration,
+    sampleCount: chunked.length,
+  };
+}
+
+function computeMedian(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}

--- a/src/features/settings/sections/audio-chunking/minutesToChunkSeconds.test.ts
+++ b/src/features/settings/sections/audio-chunking/minutesToChunkSeconds.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { minutesToChunkSeconds } from './minutesToChunkSeconds';
+
+describe('minutesToChunkSeconds', () => {
+  it('converts a whole minute count to seconds', () => {
+    expect(minutesToChunkSeconds(7)).toBe(420);
+    expect(minutesToChunkSeconds(10)).toBe(600);
+  });
+
+  it('returns null for zero or negative input', () => {
+    expect(minutesToChunkSeconds(0)).toBeNull();
+    expect(minutesToChunkSeconds(-3)).toBeNull();
+  });
+
+  it('returns null for non-finite input', () => {
+    expect(minutesToChunkSeconds(Number.NaN)).toBeNull();
+    expect(minutesToChunkSeconds(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it('preserves fractional minutes (caller may round before persisting)', () => {
+    expect(minutesToChunkSeconds(7.5)).toBe(450);
+  });
+});

--- a/src/features/settings/sections/audio-chunking/minutesToChunkSeconds.ts
+++ b/src/features/settings/sections/audio-chunking/minutesToChunkSeconds.ts
@@ -1,0 +1,15 @@
+/**
+ * Convert a user-facing minutes value into the seconds the config layer
+ * persists. The UI shows minutes (whole numbers feel natural for chunk
+ * windows) but the Rust planner consumes seconds, so this is the single
+ * conversion site for that boundary.
+ *
+ * Returns `null` for non-finite or non-positive inputs so the caller can
+ * skip the form update without re-implementing the same guards inline.
+ */
+export function minutesToChunkSeconds(minutes: number): number | null {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return null;
+  }
+  return minutes * 60;
+}

--- a/src/features/settings/sections/audio-chunking/useChunkingOverheadSummary.ts
+++ b/src/features/settings/sections/audio-chunking/useChunkingOverheadSummary.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { useApi } from '../../../../api';
+import {
+  calculateChunkingOverheadSummary,
+  ChunkingOverheadSummary,
+} from './calculateChunkingOverheadSummary';
+import { logger } from '../../../../shared/utils/logger';
+
+const EMPTY: ChunkingOverheadSummary = {
+  averageOverheadPerMinute: null,
+  longestAnalysisSeconds: null,
+  longestAnalysisAudioSeconds: null,
+  sampleCount: 0,
+};
+
+/**
+ * Load the session index and reduce it to a chunking-overhead summary.
+ *
+ * The hook is intentionally one-shot per mount — the Settings panel only
+ * opens occasionally and a fresh load on open is cheap. If a recording
+ * finishes while the panel is open the numbers stay stale until the panel
+ * is reopened; that's an acceptable trade-off compared to plumbing a
+ * subscription through the session service.
+ */
+export function useChunkingOverheadSummary(): ChunkingOverheadSummary {
+  const { sessionService } = useApi();
+  const [summary, setSummary] = useState<ChunkingOverheadSummary>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const index = await sessionService.getSessions();
+        if (cancelled) return;
+        setSummary(calculateChunkingOverheadSummary(index.sessions));
+      } catch (error) {
+        logger.warn('Failed to load chunking overhead summary', error);
+        // Leave summary as EMPTY; UI shows the "no data" placeholder.
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionService]);
+
+  return summary;
+}

--- a/src/features/settings/useSettingsForm.ts
+++ b/src/features/settings/useSettingsForm.ts
@@ -36,6 +36,10 @@ export interface SettingsFormActions {
     key: K,
     value: AppConfig["audioCompression"][K]
   ) => void;
+  setChunkingField: <K extends keyof AppConfig["audioChunking"]>(
+    key: K,
+    value: AppConfig["audioChunking"][K]
+  ) => void;
   revalidatePath: (pathField: string, kind: PathKind) => Promise<void>;
   save: () => Promise<{ ok: boolean }>;
   cancel: () => void;
@@ -99,6 +103,19 @@ export function useSettingsForm(): SettingsFormState & SettingsFormActions {
       setDraft((prev) => ({
         ...prev,
         audioCompression: { ...prev.audioCompression, [key]: value },
+      }));
+    },
+    []
+  );
+
+  const setChunkingField = useCallback(
+    <K extends keyof AppConfig["audioChunking"]>(
+      key: K,
+      value: AppConfig["audioChunking"][K]
+    ) => {
+      setDraft((prev) => ({
+        ...prev,
+        audioChunking: { ...prev.audioChunking, [key]: value },
       }));
     },
     []
@@ -182,6 +199,7 @@ export function useSettingsForm(): SettingsFormState & SettingsFormActions {
     pathValidations,
     setField,
     setCompressionField,
+    setChunkingField,
     revalidatePath,
     save,
     cancel,

--- a/src/features/settings/validateSettingsDraft.ts
+++ b/src/features/settings/validateSettingsDraft.ts
@@ -1,8 +1,21 @@
-import { AppConfig, COMPRESSION_AGE_OPTIONS } from "./appConfig";
+import { AppConfig, CHUNKING_LIMITS, COMPRESSION_AGE_OPTIONS } from "./appConfig";
+
+/**
+ * Settings-draft validation issues, keyed by either an `AppConfig` field name
+ * or one of the named cross-field issues (`ageThreshold`, chunking bounds).
+ */
+type ChunkingFieldKey =
+  | "chunkingMinDuration"
+  | "chunkingMaxDuration"
+  | "chunkingMinMaxOrder"
+  | "chunkingSilenceThreshold"
+  | "chunkingMinSilenceDuration";
 
 export interface SettingsDraftIssues {
   /** Field-keyed issue messages — empty means valid. */
-  fieldErrors: Partial<Record<keyof AppConfig | "ageThreshold", string>>;
+  fieldErrors: Partial<
+    Record<keyof AppConfig | "ageThreshold" | ChunkingFieldKey, string>
+  >;
   /** True when no field has a save-blocking issue. */
   isValid: boolean;
 }
@@ -28,6 +41,41 @@ export function validateSettingsDraft(draft: AppConfig): SettingsDraftIssues {
     fieldErrors.ageThreshold = `Age threshold must be one of: ${COMPRESSION_AGE_OPTIONS.join(
       ", "
     )} days`;
+  }
+
+  const chunking = draft.audioChunking;
+  const minBounds = CHUNKING_LIMITS.minChunkDurationSec;
+  const maxBounds = CHUNKING_LIMITS.maxChunkDurationSec;
+  const thresholdBounds = CHUNKING_LIMITS.silenceThresholdDb;
+  const silenceBounds = CHUNKING_LIMITS.minSilenceDurationSec;
+
+  if (
+    chunking.minChunkDurationSec < minBounds.min ||
+    chunking.minChunkDurationSec > minBounds.max
+  ) {
+    fieldErrors.chunkingMinDuration = `Min chunk duration must be ${minBounds.min}–${minBounds.max} sec`;
+  }
+  if (
+    chunking.maxChunkDurationSec < maxBounds.min ||
+    chunking.maxChunkDurationSec > maxBounds.max
+  ) {
+    fieldErrors.chunkingMaxDuration = `Max chunk duration must be ${maxBounds.min}–${maxBounds.max} sec`;
+  }
+  if (chunking.minChunkDurationSec >= chunking.maxChunkDurationSec) {
+    fieldErrors.chunkingMinMaxOrder =
+      "Min chunk duration must be less than max chunk duration";
+  }
+  if (
+    chunking.silenceThresholdDb < thresholdBounds.min ||
+    chunking.silenceThresholdDb > thresholdBounds.max
+  ) {
+    fieldErrors.chunkingSilenceThreshold = `Silence threshold must be ${thresholdBounds.min}–${thresholdBounds.max} dB`;
+  }
+  if (
+    chunking.minSilenceDurationSec < silenceBounds.min ||
+    chunking.minSilenceDurationSec > silenceBounds.max
+  ) {
+    fieldErrors.chunkingMinSilenceDuration = `Min silence duration must be ${silenceBounds.min}–${silenceBounds.max} sec`;
   }
 
   return {

--- a/src/features/transcription/prepareProgressDisplay.test.ts
+++ b/src/features/transcription/prepareProgressDisplay.test.ts
@@ -4,109 +4,160 @@ import { TranscriptionProgress } from '../../api';
 
 const mockFormatDuration = (seconds: number): string => `${Math.round(seconds)}s`;
 
-describe('prepareProgressDisplay', () => {
-  it('should not display when no estimate available', () => {
-    const progress: TranscriptionProgress = {
-      estimatedSeconds: null,
-      elapsedSeconds: 5,
-      progressPercent: 0,
-      hasEstimate: false,
-      remainingSeconds: null,
-    };
+const baseProgress: TranscriptionProgress = {
+  estimatedSeconds: null,
+  elapsedSeconds: 0,
+  progressPercent: 0,
+  hasEstimate: false,
+  remainingSeconds: null,
+  chunkInfo: null,
+};
 
-    const result = prepareProgressDisplay(progress, mockFormatDuration);
+describe('prepareProgressDisplay', () => {
+  it('should not display when no estimate and no chunk info', () => {
+    const result = prepareProgressDisplay(
+      { ...baseProgress, elapsedSeconds: 5 },
+      mockFormatDuration
+    );
 
     expect(result.shouldDisplay).toBe(false);
     expect(result.estimatedText).toBe('');
     expect(result.remainingText).toBe(null);
     expect(result.progressPercent).toBe(0);
+    expect(result.chunkLabel).toBe(null);
   });
 
   it('should display progress when estimate is available', () => {
-    const progress: TranscriptionProgress = {
-      estimatedSeconds: 60,
-      elapsedSeconds: 20,
-      progressPercent: 33,
-      hasEstimate: true,
-      remainingSeconds: 40,
-    };
-
-    const result = prepareProgressDisplay(progress, mockFormatDuration);
+    const result = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 60,
+        elapsedSeconds: 20,
+        progressPercent: 33,
+        hasEstimate: true,
+        remainingSeconds: 40,
+      },
+      mockFormatDuration
+    );
 
     expect(result.shouldDisplay).toBe(true);
     expect(result.estimatedText).toBe('~60s');
     expect(result.remainingText).toBe('(40s remaining)');
     expect(result.progressPercent).toBe(33);
+    expect(result.chunkLabel).toBe(null);
   });
 
   it('should not show remaining time when zero or null', () => {
-    const progressZero: TranscriptionProgress = {
-      estimatedSeconds: 60,
-      elapsedSeconds: 60,
-      progressPercent: 95,
-      hasEstimate: true,
-      remainingSeconds: 0,
-    };
-
-    const resultZero = prepareProgressDisplay(progressZero, mockFormatDuration);
+    const resultZero = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 60,
+        elapsedSeconds: 60,
+        progressPercent: 95,
+        hasEstimate: true,
+        remainingSeconds: 0,
+      },
+      mockFormatDuration
+    );
 
     expect(resultZero.shouldDisplay).toBe(true);
     expect(resultZero.estimatedText).toBe('~60s');
     expect(resultZero.remainingText).toBe(null);
 
-    const progressNull: TranscriptionProgress = {
-      estimatedSeconds: 60,
-      elapsedSeconds: 60,
-      progressPercent: 95,
-      hasEstimate: true,
-      remainingSeconds: null,
-    };
-
-    const resultNull = prepareProgressDisplay(progressNull, mockFormatDuration);
+    const resultNull = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 60,
+        elapsedSeconds: 60,
+        progressPercent: 95,
+        hasEstimate: true,
+        remainingSeconds: null,
+      },
+      mockFormatDuration
+    );
     expect(resultNull.remainingText).toBe(null);
   });
 
   it('should not show remaining time when negative', () => {
-    const progress: TranscriptionProgress = {
-      estimatedSeconds: 60,
-      elapsedSeconds: 70,
-      progressPercent: 95,
-      hasEstimate: true,
-      remainingSeconds: -10,
-    };
-
-    const result = prepareProgressDisplay(progress, mockFormatDuration);
+    const result = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 60,
+        elapsedSeconds: 70,
+        progressPercent: 95,
+        hasEstimate: true,
+        remainingSeconds: -10,
+      },
+      mockFormatDuration
+    );
 
     expect(result.remainingText).toBe(null);
   });
 
   it('should use provided format function for durations', () => {
     const customFormat = (s: number) => `${s} seconds`;
-    const progress: TranscriptionProgress = {
-      estimatedSeconds: 120,
-      elapsedSeconds: 30,
-      progressPercent: 25,
-      hasEstimate: true,
-      remainingSeconds: 90,
-    };
-
-    const result = prepareProgressDisplay(progress, customFormat);
+    const result = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 120,
+        elapsedSeconds: 30,
+        progressPercent: 25,
+        hasEstimate: true,
+        remainingSeconds: 90,
+      },
+      customFormat
+    );
 
     expect(result.estimatedText).toBe('~120 seconds');
     expect(result.remainingText).toBe('(90 seconds remaining)');
   });
 
   it('should handle edge case of estimate without hasEstimate flag', () => {
-    const progress: TranscriptionProgress = {
-      estimatedSeconds: 60,
-      elapsedSeconds: 10,
-      progressPercent: 16,
-      hasEstimate: false, // Inconsistent state
-      remainingSeconds: 50,
-    };
-
-    const result = prepareProgressDisplay(progress, mockFormatDuration);
+    const result = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 60,
+        elapsedSeconds: 10,
+        progressPercent: 16,
+        hasEstimate: false, // Inconsistent state
+        remainingSeconds: 50,
+      },
+      mockFormatDuration
+    );
 
     expect(result.shouldDisplay).toBe(false);
+  });
+
+  it('should format chunk label from chunkInfo', () => {
+    const result = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        estimatedSeconds: 60,
+        elapsedSeconds: 20,
+        progressPercent: 33,
+        hasEstimate: true,
+        remainingSeconds: 40,
+        chunkInfo: { current: 2, total: 3 },
+      },
+      mockFormatDuration
+    );
+
+    expect(result.chunkLabel).toBe('chunk 2 of 3');
+  });
+
+  it('should show chunk label even before historical estimate arrives', () => {
+    // A chunked recording may emit chunk 1 of N before the estimator finishes.
+    // We want the UI to immediately show position so the user sees something.
+    const result = prepareProgressDisplay(
+      {
+        ...baseProgress,
+        chunkInfo: { current: 1, total: 4 },
+      },
+      mockFormatDuration
+    );
+
+    expect(result.shouldDisplay).toBe(true);
+    expect(result.chunkLabel).toBe('chunk 1 of 4');
+    expect(result.estimatedText).toBe('');
   });
 });

--- a/src/features/transcription/prepareProgressDisplay.ts
+++ b/src/features/transcription/prepareProgressDisplay.ts
@@ -12,6 +12,12 @@ export interface ProgressDisplayData {
   remainingText: string | null;
   /** Progress percentage for progress bar */
   progressPercent: number;
+  /**
+   * Chunk-position label like "chunk 2 of 3", or null when the recording is
+   * unchunked. Surfaced alongside the time estimate so the user sees both
+   * dimensions of progress at once.
+   */
+  chunkLabel: string | null;
 }
 
 /**
@@ -28,13 +34,20 @@ export function prepareProgressDisplay(
   progress: TranscriptionProgress,
   formatDuration: (seconds: number) => string
 ): ProgressDisplayData {
-  // Don't show progress if no estimate available
+  const chunkLabel = progress.chunkInfo
+    ? `chunk ${progress.chunkInfo.current} of ${progress.chunkInfo.total}`
+    : null;
+
+  // Show the section whenever we have an estimate OR a chunk position. A
+  // chunked recording may emit `chunk 1 of N` before the historical estimate
+  // arrives, and the user wants to see that immediately.
   if (!progress.hasEstimate || progress.estimatedSeconds === null) {
     return {
-      shouldDisplay: false,
+      shouldDisplay: chunkLabel !== null,
       estimatedText: '',
       remainingText: null,
       progressPercent: 0,
+      chunkLabel,
     };
   }
 
@@ -51,5 +64,6 @@ export function prepareProgressDisplay(
     estimatedText,
     remainingText,
     progressPercent: progress.progressPercent,
+    chunkLabel,
   };
 }

--- a/src/features/transcription/useTranscriptionProgress.ts
+++ b/src/features/transcription/useTranscriptionProgress.ts
@@ -1,16 +1,25 @@
 import { useEffect, useState, useRef } from 'react';
-import { useApi, TranscriptionProgress } from '../../api';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  useApi,
+  TranscriptionProgress,
+  ChunkProgressInfo,
+  TranscriptionProgressEvent,
+} from '../../api';
 import { calculateProgressPercent } from './calculateProgressPercent';
 
 /**
  * Hook to track transcription progress with time estimates
  *
- * Fetches historical estimates and tracks elapsed time to show progress.
- * Updates every second while transcription is active.
+ * Fetches a historical time-based estimate and tracks elapsed time so the
+ * UI can show a progress bar. Also subscribes to the `transcription-progress`
+ * Tauri event so chunked recordings can surface "chunk N of M" while each
+ * chunk's Whisper pass runs.
  *
  * @param isTranscribing - Whether transcription is currently active
  * @param audioDurationSeconds - Duration of the audio being transcribed
- * @returns Progress data including estimate, elapsed time, and percentage
+ * @returns Progress data including estimate, elapsed time, percentage, and
+ *          chunk position (null for unchunked recordings).
  */
 export function useTranscriptionProgress(
   isTranscribing: boolean,
@@ -19,6 +28,7 @@ export function useTranscriptionProgress(
   const { transcriptionStatsService } = useApi();
   const [estimatedSeconds, setEstimatedSeconds] = useState<number | null>(null);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [chunkInfo, setChunkInfo] = useState<ChunkProgressInfo | null>(null);
   const startTimeRef = useRef<number | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -32,22 +42,11 @@ export function useTranscriptionProgress(
 
     async function fetchEstimate() {
       try {
-        console.log(
-          '[useTranscriptionProgress] Fetching estimate for audio duration:',
-          audioDurationSeconds
-        );
         const estimate = await transcriptionStatsService.getTranscriptionEstimate(
           audioDurationSeconds
         );
-
-        console.log('[useTranscriptionProgress] Received estimate:', estimate);
-
         if (mounted && estimate) {
           setEstimatedSeconds(estimate.estimatedSeconds);
-          console.log(
-            '[useTranscriptionProgress] Set estimated seconds:',
-            estimate.estimatedSeconds
-          );
         }
       } catch (error) {
         // Estimate fetch failed - continue without estimate
@@ -69,6 +68,7 @@ export function useTranscriptionProgress(
       startTimeRef.current = null;
       setElapsedSeconds(0);
       setEstimatedSeconds(null);
+      setChunkInfo(null);
 
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
@@ -78,12 +78,10 @@ export function useTranscriptionProgress(
       return;
     }
 
-    // Start tracking time
     if (!startTimeRef.current) {
       startTimeRef.current = Date.now();
     }
 
-    // Update elapsed time every second
     intervalRef.current = setInterval(() => {
       if (startTimeRef.current) {
         const elapsed = (Date.now() - startTimeRef.current) / 1000;
@@ -99,13 +97,44 @@ export function useTranscriptionProgress(
     };
   }, [isTranscribing]);
 
-  // Calculate progress percentage
+  // Subscribe to per-chunk progress events. Single-shot transcriptions never
+  // fire this, so `chunkInfo` stays null and the UI shows the time-based
+  // estimate only.
+  useEffect(() => {
+    if (!isTranscribing) return;
+
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+
+    listen<TranscriptionProgressEvent>('transcription-progress', (event) => {
+      if (cancelled) return;
+      setChunkInfo({
+        current: event.payload.current,
+        total: event.payload.total,
+      });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      })
+      .catch((error) => {
+        console.warn('Failed to subscribe to transcription-progress:', error);
+      });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [isTranscribing]);
+
   const progressPercent = calculateProgressPercent(
     elapsedSeconds,
     estimatedSeconds
   );
 
-  // Calculate remaining time
   const remainingSeconds =
     estimatedSeconds !== null
       ? Math.max(0, estimatedSeconds - elapsedSeconds)
@@ -117,5 +146,6 @@ export function useTranscriptionProgress(
     progressPercent,
     hasEstimate: estimatedSeconds !== null,
     remainingSeconds,
+    chunkInfo,
   };
 }


### PR DESCRIPTION
## Summary
- Splits long recordings at natural silence boundaries via FFmpeg's `silencedetect`, transcribes each chunk sequentially, and stitches the transcripts, eliminating Whisper's >20-minute repetition loops.
- Adds a new Audio Chunking section under the Transcription settings tab with min/max chunk duration controls and an overhead summary; on by default, silently disabled when FFmpeg isn't configured.
- Surfaces per-chunk progress ("chunk N of M") in the recording controls and session viewer via a new `transcription-progress` Tauri event.
