### PR TITLE
Fix recording performance: virtualize session list, throttle polling, pause when hidden

### DIFF
--- a/src/app/useRecordingWorkflow.test.ts
+++ b/src/app/useRecordingWorkflow.test.ts
@@ -422,12 +422,15 @@ describe('useRecordingWorkflow', () => {
 
     expect(result.current.recordingStatus).toBe('recording');
 
-    // Wait for the interval to trigger (runs every 100ms)
-    // Using waitFor with real timers is more reliable than fake timers
-    await waitFor(() => {
-      expect(mockRecordingService.getRecordingDuration).toHaveBeenCalled();
-      expect(result.current.recordingDuration).toBe(5.5);
-    });
+    // Wait for the interval to trigger (runs every 500ms).
+    // Using waitFor with real timers is more reliable than fake timers.
+    await waitFor(
+      () => {
+        expect(mockRecordingService.getRecordingDuration).toHaveBeenCalled();
+        expect(result.current.recordingDuration).toBe(5.5);
+      },
+      { timeout: 2000 }
+    );
   });
 
   it('should allow manual session selection', async () => {

--- a/src/app/useRecordingWorkflow.ts
+++ b/src/app/useRecordingWorkflow.ts
@@ -10,6 +10,7 @@ import {
 } from '../api';
 import { listen } from '@tauri-apps/api/event';
 import { logger } from '../shared/utils/logger';
+import { useDocumentActivity } from '../shared/utils/useDocumentActivity';
 import { useRecordingCues } from '../features/audio-feedback/useRecordingCues';
 
 /**
@@ -145,6 +146,7 @@ interface RecordingWorkflowActions {
 export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkflowActions {
   const { sessionService, recordingService } = useApi();
   const cues = useRecordingCues();
+  const activity = useDocumentActivity();
   const [sessions, setSessions] = useState<Session[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>('idle');
@@ -310,11 +312,19 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
     };
   }, [loadSessions]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Timer for recording duration
+  // Timer for recording duration. Display granularity is whole seconds
+  // (MM:SS), so polling at 2 Hz keeps the timer visually current without
+  // re-rendering the App tree 10x/sec — every tick rippled through React
+  // reconciliation and forced a repaint of the timer span. Skip polling
+  // entirely when the window is hidden: the timer is offscreen, and the
+  // next interval tick after un-hide refreshes it within 500 ms.
   useEffect(() => {
     let interval: number | undefined;
 
-    if (recordingStatus === 'recording' || recordingStatus === 'paused') {
+    const isTimingRecording =
+      recordingStatus === 'recording' || recordingStatus === 'paused';
+
+    if (isTimingRecording && activity !== 'hidden') {
       interval = window.setInterval(async () => {
         try {
           const duration = await recordingService.getRecordingDuration();
@@ -322,15 +332,15 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
         } catch (error) {
           logger.error("Failed to get recording duration:", error);
         }
-      }, 100);
-    } else {
+      }, 500);
+    } else if (!isTimingRecording) {
       setRecordingDuration(0);
     }
 
     return () => {
       if (interval) clearInterval(interval);
     };
-  }, [recordingStatus, recordingService]);
+  }, [recordingStatus, recordingService, activity]);
 
   const selectedSession = findSessionById(sessions, selectedId);
 

--- a/src/features/recording/RecordingControls.tsx
+++ b/src/features/recording/RecordingControls.tsx
@@ -106,7 +106,7 @@ export default function RecordingControls({
           ✕ Cancel
         </Button>
 
-        <Button variant="danger" onClick={onStopRecording} className="btn-pulse">
+        <Button variant="danger" onClick={onStopRecording}>
           ■ Stop
         </Button>
       </div>

--- a/src/features/recording/useAudioLevels.test.ts
+++ b/src/features/recording/useAudioLevels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { renderHook } from "@testing-library/react";
-import { useAudioLevels } from "./useAudioLevels";
+import { act, renderHook } from "@testing-library/react";
+import { selectAudioLevelPollInterval, useAudioLevels } from "./useAudioLevels";
 import { ApiProvider, MockRecordingService } from "../../api";
 import React from "react";
 
@@ -9,17 +9,56 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
 
+describe("selectAudioLevelPollInterval", () => {
+  it("returns 100 ms when the window is active", () => {
+    expect(selectAudioLevelPollInterval("active")).toBe(100);
+  });
+
+  it("returns a slower interval when the window is idle", () => {
+    const interval = selectAudioLevelPollInterval("idle");
+    expect(interval).not.toBeNull();
+    expect(interval!).toBeGreaterThan(100);
+  });
+
+  it("returns null (no polling) when the window is hidden", () => {
+    expect(selectAudioLevelPollInterval("hidden")).toBeNull();
+  });
+});
+
 describe("useAudioLevels", () => {
   let mockRecordingService: MockRecordingService;
+
+  const originalVisibility = Object.getOwnPropertyDescriptor(
+    Document.prototype,
+    "visibilityState"
+  );
+  const originalHasFocus = document.hasFocus;
+
+  function setVisibility(value: DocumentVisibilityState) {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  function setHasFocus(value: boolean) {
+    document.hasFocus = () => value;
+  }
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockRecordingService = new MockRecordingService();
+    setVisibility("visible");
+    setHasFocus(true);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    if (originalVisibility) {
+      Object.defineProperty(Document.prototype, "visibilityState", originalVisibility);
+    }
+    document.hasFocus = originalHasFocus;
   });
 
   const wrapper = ({ children }: { children: React.ReactNode }) =>
@@ -64,7 +103,7 @@ describe("useAudioLevels", () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it("should poll audio levels every 50ms when recording", async () => {
+  it("should poll audio levels every 100ms when recording and active", async () => {
     const spy = vi.spyOn(mockRecordingService, "getAudioLevels");
 
     renderHook(() => useAudioLevels("recording"), { wrapper });
@@ -73,12 +112,12 @@ describe("useAudioLevels", () => {
     await vi.advanceTimersByTimeAsync(20);
     expect(spy).toHaveBeenCalledTimes(1);
 
-    // After 50ms
-    await vi.advanceTimersByTimeAsync(50);
+    // After 100ms
+    await vi.advanceTimersByTimeAsync(100);
     expect(spy).toHaveBeenCalledTimes(2);
 
-    // After another 50ms
-    await vi.advanceTimersByTimeAsync(50);
+    // After another 100ms
+    await vi.advanceTimersByTimeAsync(100);
     expect(spy).toHaveBeenCalledTimes(3);
   });
 
@@ -107,7 +146,7 @@ describe("useAudioLevels", () => {
 
     // Should not poll anymore
     const callCountBeforePause = spy.mock.calls.length;
-    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(200);
     expect(spy).toHaveBeenCalledTimes(callCountBeforePause);
   });
 
@@ -122,7 +161,67 @@ describe("useAudioLevels", () => {
     unmount();
 
     // Should not call after unmount
-    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(200);
     expect(spy).toHaveBeenCalledTimes(callCountBeforeUnmount);
+  });
+
+  it("stops polling when the window becomes hidden, and resumes on un-hide", async () => {
+    const spy = vi.spyOn(mockRecordingService, "getAudioLevels");
+
+    renderHook(() => useAudioLevels("recording"), { wrapper });
+
+    // Initial fetch on mount, plus one interval tick
+    await vi.advanceTimersByTimeAsync(20);
+    await vi.advanceTimersByTimeAsync(100);
+    const callCountBeforeHide = spy.mock.calls.length;
+    expect(callCountBeforeHide).toBeGreaterThanOrEqual(2);
+
+    // Hide the window — polling should stop
+    await act(async () => {
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(spy).toHaveBeenCalledTimes(callCountBeforeHide);
+
+    // Un-hide — polling resumes and fetches immediately
+    await act(async () => {
+      setVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+      await Promise.resolve();
+    });
+
+    await vi.advanceTimersByTimeAsync(20);
+    expect(spy.mock.calls.length).toBeGreaterThan(callCountBeforeHide);
+  });
+
+  it("polls at the slower idle interval when the window loses focus", async () => {
+    const spy = vi.spyOn(mockRecordingService, "getAudioLevels");
+
+    renderHook(() => useAudioLevels("recording"), { wrapper });
+
+    // Burn through the active-state initial fetch.
+    await vi.advanceTimersByTimeAsync(20);
+
+    // Blur the window — effect re-runs with the idle interval, firing one
+    // immediate refetch and then ticking every 500 ms.
+    await act(async () => {
+      setHasFocus(false);
+      window.dispatchEvent(new Event("blur"));
+      await Promise.resolve();
+    });
+    await vi.advanceTimersByTimeAsync(20);
+
+    const callCountAfterBlur = spy.mock.calls.length;
+
+    // 100 ms (the old active interval) elapses — no idle tick has fired yet.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(spy).toHaveBeenCalledTimes(callCountAfterBlur);
+
+    // After the full idle interval elapses, a tick should have fired.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(spy.mock.calls.length).toBeGreaterThan(callCountAfterBlur);
   });
 });

--- a/src/features/recording/useAudioLevels.ts
+++ b/src/features/recording/useAudioLevels.ts
@@ -2,17 +2,50 @@ import { useState, useEffect, useRef } from "react";
 import { useApi } from "../../api";
 import { RecordingStatus } from "../../api";
 import { logger } from "../../shared/utils/logger";
+import {
+  DocumentActivity,
+  useDocumentActivity,
+} from "../../shared/utils/useDocumentActivity";
 
 /**
- * Hook to fetch and manage real-time audio levels during recording
+ * Polling interval selected by current window-attention state.
  *
- * Polls the backend for audio level data every 50ms while recording is active.
- * Returns empty array when not recording or paused.
+ * - `active`: window is focused, user is plausibly watching the visualization.
+ *   100 ms feels responsive without rendering the canvas faster than the
+ *   bars actually need to update.
+ * - `idle`: window is visible but not focused (user is in another app).
+ *   Coarser polling — the visualization is just a "mic is alive" signal at
+ *   this point, fidelity does not matter.
+ * - `hidden`: window is minimized or completely covered. Skip polling
+ *   entirely — the canvas cannot be seen, every redraw is pure waste.
+ */
+const AUDIO_LEVEL_POLL_INTERVAL_MS: Record<DocumentActivity, number | null> = {
+  active: 100,
+  idle: 500,
+  hidden: null,
+};
+
+export function selectAudioLevelPollInterval(
+  activity: DocumentActivity
+): number | null {
+  return AUDIO_LEVEL_POLL_INTERVAL_MS[activity];
+}
+
+/**
+ * Hook to fetch and manage real-time audio levels during recording.
+ *
+ * Polls the backend for audio level data while recording is active, with a
+ * cadence that adapts to the window's user-attention state. Returns empty
+ * array when not recording or paused; preserves the last known levels while
+ * the window is hidden so the visualization does not flicker on un-hide.
  */
 export function useAudioLevels(recordingStatus: RecordingStatus): number[] {
   const { recordingService } = useApi();
+  const activity = useDocumentActivity();
   const [audioLevels, setAudioLevels] = useState<number[]>([]);
   const intervalRef = useRef<number | null>(null);
+
+  const pollInterval = selectAudioLevelPollInterval(activity);
 
   useEffect(() => {
     // Only poll when actively recording (not idle or paused)
@@ -25,7 +58,16 @@ export function useAudioLevels(recordingStatus: RecordingStatus): number[] {
       return;
     }
 
-    // Start polling for audio levels
+    // Window is hidden — pause polling but keep the last levels in state so
+    // the canvas does not flash blank when the user un-minimizes.
+    if (pollInterval === null) {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+
     const pollAudioLevels = async () => {
       try {
         const levels = await recordingService.getAudioLevels();
@@ -36,11 +78,11 @@ export function useAudioLevels(recordingStatus: RecordingStatus): number[] {
       }
     };
 
-    // Initial fetch
+    // Initial fetch on (re)start, so newly-active state shows fresh data
+    // within one tick instead of waiting a full interval.
     pollAudioLevels();
 
-    // Poll every 50ms for smooth visualization
-    intervalRef.current = window.setInterval(pollAudioLevels, 50);
+    intervalRef.current = window.setInterval(pollAudioLevels, pollInterval);
 
     return () => {
       if (intervalRef.current !== null) {
@@ -48,7 +90,7 @@ export function useAudioLevels(recordingStatus: RecordingStatus): number[] {
         intervalRef.current = null;
       }
     };
-  }, [recordingStatus, recordingService]);
+  }, [recordingStatus, recordingService, pollInterval]);
 
   return audioLevels;
 }

--- a/src/features/sessions/SessionList.css
+++ b/src/features/sessions/SessionList.css
@@ -43,6 +43,20 @@
   padding: var(--space-sm) 0;
 }
 
+/* Virtualized list scaffolding: spacer holds total scrollable height,
+   window positions the rendered slice via translateY. */
+.session-list-virtual-spacer {
+  position: relative;
+  width: 100%;
+}
+
+.session-list-virtual-window {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
 /* Custom scrollbar for better aesthetics */
 .session-list-items::-webkit-scrollbar {
   width: 8px;

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -1,5 +1,7 @@
+import { memo, useRef } from "react";
 import { Session } from "../../api";
 import SessionListItem from "./SessionListItem";
+import { useVirtualizedList } from "./useVirtualizedList";
 import "./SessionList.css";
 
 interface SessionListProps {
@@ -8,34 +10,56 @@ interface SessionListProps {
   onSelectSession: (id: string) => void;
 }
 
-/**
- * SessionList Component
- *
- * Displays a scrollable list of recording sessions in the sidebar.
- * Uses SessionListItem for consistent presentation.
- */
-export default function SessionList({
+// Matches the rendered height of `.session-list-item`: 8px margin top + 1px
+// border + 12px padding top + ~22px header line + 8px header margin + ~18px
+// preview line + 12px padding bottom + 1px border + 8px margin bottom. The
+// overscan in useVirtualizedList absorbs minor drift.
+const SESSION_ITEM_HEIGHT = 92;
+
+function SessionListImpl({
   sessions,
   selectedId,
   onSelectSession,
 }: SessionListProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { startIndex, endIndex, offsetY, totalHeight } = useVirtualizedList(
+    scrollContainerRef,
+    sessions.length,
+    SESSION_ITEM_HEIGHT
+  );
+
+  const visibleSessions = sessions.slice(startIndex, endIndex);
+
   return (
     <div className="session-list">
       <h2 className="session-list-title">Sessions</h2>
-      <div className="session-list-items">
+      <div className="session-list-items" ref={scrollContainerRef}>
         {sessions.length === 0 ? (
           <div className="session-list-empty">No recordings yet</div>
         ) : (
-          sessions.map((session) => (
-            <SessionListItem
-              key={session.id}
-              session={session}
-              isSelected={session.id === selectedId}
-              onSelect={() => onSelectSession(session.id)}
-            />
-          ))
+          <div
+            className="session-list-virtual-spacer"
+            style={{ height: totalHeight }}
+          >
+            <div
+              className="session-list-virtual-window"
+              style={{ transform: `translateY(${offsetY}px)` }}
+            >
+              {visibleSessions.map((session) => (
+                <SessionListItem
+                  key={session.id}
+                  session={session}
+                  isSelected={session.id === selectedId}
+                  onSelect={onSelectSession}
+                />
+              ))}
+            </div>
+          </div>
         )}
       </div>
     </div>
   );
 }
+
+const SessionList = memo(SessionListImpl);
+export default SessionList;

--- a/src/features/sessions/SessionListItem.css
+++ b/src/features/sessions/SessionListItem.css
@@ -9,7 +9,12 @@
   border: 1px solid var(--color-border-light);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all var(--transition-base);
+  /* Specific transitions instead of `all` — the WebView compositor was
+     monitoring every property on 1400 list items, dominating GPU during
+     recording when the parent re-renders at 10 Hz. */
+  transition:
+    background-color var(--transition-base),
+    border-color var(--transition-base);
 }
 
 /* Unselected hover state - subtle */

--- a/src/features/sessions/SessionListItem.tsx
+++ b/src/features/sessions/SessionListItem.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from "react";
 import { Session } from "../../api";
 import { formatShortTimestamp } from "../../shared/formatters/date-time";
 import { formatDuration } from "../../shared/formatters/duration";
@@ -7,26 +8,20 @@ import "./SessionListItem.css";
 interface SessionListItemProps {
   session: Session;
   isSelected: boolean;
-  onSelect: () => void;
+  onSelect: (id: string) => void;
 }
 
-/**
- * L2 SessionListItem Component
- *
- * Renders a single session in the list with subtle selection states
- * and hover effects that follow the design system guidelines.
- */
-export default function SessionListItem({
-  session,
-  isSelected,
-  onSelect,
-}: SessionListItemProps) {
+function SessionListItemImpl({ session, isSelected, onSelect }: SessionListItemProps) {
   const isProcessing = session.preview === "Processing...";
+
+  const handleClick = useCallback(() => {
+    onSelect(session.id);
+  }, [onSelect, session.id]);
 
   return (
     <div
       className={`session-list-item ${isSelected ? "session-list-item-selected" : ""} ${isProcessing ? "session-list-item-processing" : ""}`}
-      onClick={onSelect}
+      onClick={handleClick}
     >
       <div className="session-list-item-header">
         <span className="session-list-item-icon">
@@ -45,3 +40,6 @@ export default function SessionListItem({
     </div>
   );
 }
+
+const SessionListItem = memo(SessionListItemImpl);
+export default SessionListItem;

--- a/src/features/sessions/useVirtualizedList.test.ts
+++ b/src/features/sessions/useVirtualizedList.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { computeVirtualRange } from './useVirtualizedList';
+
+describe('computeVirtualRange', () => {
+  it('returns empty range when itemCount is zero', () => {
+    const result = computeVirtualRange({
+      itemCount: 0,
+      itemHeight: 80,
+      containerHeight: 600,
+      scrollTop: 0,
+    });
+    expect(result).toEqual({ startIndex: 0, endIndex: 0, offsetY: 0, totalHeight: 0 });
+  });
+
+  it('returns empty range when itemHeight is zero', () => {
+    const result = computeVirtualRange({
+      itemCount: 100,
+      itemHeight: 0,
+      containerHeight: 600,
+      scrollTop: 0,
+    });
+    expect(result.endIndex).toBe(0);
+  });
+
+  it('renders only the first window when scrolled to top', () => {
+    const result = computeVirtualRange({
+      itemCount: 1400,
+      itemHeight: 80,
+      containerHeight: 600,
+      scrollTop: 0,
+      overscan: 5,
+    });
+
+    expect(result.startIndex).toBe(0);
+    // 600 / 80 = 7.5 -> ceil 8 visible, + 5 overscan past = 13
+    expect(result.endIndex).toBe(13);
+    expect(result.offsetY).toBe(0);
+    expect(result.totalHeight).toBe(1400 * 80);
+  });
+
+  it('includes overscan rows before the visible window when scrolled', () => {
+    const result = computeVirtualRange({
+      itemCount: 1400,
+      itemHeight: 80,
+      containerHeight: 600,
+      scrollTop: 800, // row 10 at top
+      overscan: 5,
+    });
+
+    expect(result.startIndex).toBe(5); // 10 - 5 overscan
+    expect(result.endIndex).toBe(10 + 8 + 5); // raw + visible + overscan = 23
+    expect(result.offsetY).toBe(5 * 80);
+  });
+
+  it('clamps the end index to itemCount near the bottom of the list', () => {
+    const result = computeVirtualRange({
+      itemCount: 100,
+      itemHeight: 80,
+      containerHeight: 600,
+      scrollTop: 80 * 95,
+      overscan: 5,
+    });
+
+    expect(result.endIndex).toBe(100);
+    expect(result.startIndex).toBeLessThan(100);
+  });
+
+  it('preserves total scroll height regardless of window position', () => {
+    const topRange = computeVirtualRange({
+      itemCount: 1400,
+      itemHeight: 80,
+      containerHeight: 600,
+      scrollTop: 0,
+    });
+    const middleRange = computeVirtualRange({
+      itemCount: 1400,
+      itemHeight: 80,
+      containerHeight: 600,
+      scrollTop: 50000,
+    });
+
+    expect(topRange.totalHeight).toBe(middleRange.totalHeight);
+    expect(topRange.totalHeight).toBe(1400 * 80);
+  });
+});

--- a/src/features/sessions/useVirtualizedList.ts
+++ b/src/features/sessions/useVirtualizedList.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState, RefObject } from 'react';
+
+export interface VirtualizedRange {
+  startIndex: number;
+  endIndex: number;
+  offsetY: number;
+  totalHeight: number;
+}
+
+export interface VirtualizedListOptions {
+  itemCount: number;
+  itemHeight: number;
+  overscan?: number;
+  containerHeight: number;
+  scrollTop: number;
+}
+
+/**
+ * Compute the slice of items that should render given a scrollable viewport.
+ *
+ * Why: rendering all N items keeps every node and CSS layer alive in the
+ * compositor. With ~1400 sessions and a 10Hz parent re-render during
+ * recording, WebView2 burned ~12% GPU recomputing styles for offscreen rows.
+ * Restricting work to the visible window plus an overscan buffer keeps the
+ * DOM small (~20 nodes) without flashing blank rows when the user scrolls.
+ */
+export function computeVirtualRange(opts: VirtualizedListOptions): VirtualizedRange {
+  const { itemCount, itemHeight, containerHeight, scrollTop, overscan = 5 } = opts;
+
+  if (itemCount === 0 || itemHeight <= 0) {
+    return { startIndex: 0, endIndex: 0, offsetY: 0, totalHeight: 0 };
+  }
+
+  const rawStart = Math.floor(scrollTop / itemHeight);
+  const visibleCount = Math.ceil(containerHeight / itemHeight);
+
+  const startIndex = Math.max(0, rawStart - overscan);
+  const endIndex = Math.min(itemCount, rawStart + visibleCount + overscan);
+
+  return {
+    startIndex,
+    endIndex,
+    offsetY: startIndex * itemHeight,
+    totalHeight: itemCount * itemHeight,
+  };
+}
+
+/**
+ * React hook that tracks scroll position on a container and returns the
+ * visible item window. Falls back to rendering the first window when the
+ * container has not yet measured.
+ */
+export function useVirtualizedList(
+  containerRef: RefObject<HTMLElement | null>,
+  itemCount: number,
+  itemHeight: number,
+  overscan = 5
+): VirtualizedRange {
+  const [scrollTop, setScrollTop] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    setContainerHeight(container.clientHeight);
+
+    const handleScroll = () => {
+      if (rafRef.current !== null) return;
+      rafRef.current = window.requestAnimationFrame(() => {
+        rafRef.current = null;
+        setScrollTop(container.scrollTop);
+      });
+    };
+
+    const resizeObserver = new ResizeObserver(() => {
+      setContainerHeight(container.clientHeight);
+    });
+    resizeObserver.observe(container);
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+      resizeObserver.disconnect();
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [containerRef]);
+
+  return computeVirtualRange({
+    itemCount,
+    itemHeight,
+    containerHeight,
+    scrollTop,
+    overscan,
+  });
+}

--- a/src/shared/utils/useDocumentActivity.test.ts
+++ b/src/shared/utils/useDocumentActivity.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { detectActivity, useDocumentActivity } from './useDocumentActivity';
+
+describe('detectActivity', () => {
+  it('returns hidden when the document is hidden, regardless of focus', () => {
+    expect(detectActivity('hidden', true)).toBe('hidden');
+    expect(detectActivity('hidden', false)).toBe('hidden');
+  });
+
+  it('returns idle when visible but unfocused', () => {
+    expect(detectActivity('visible', false)).toBe('idle');
+  });
+
+  it('returns active when visible and focused', () => {
+    expect(detectActivity('visible', true)).toBe('active');
+  });
+});
+
+describe('useDocumentActivity', () => {
+  const originalVisibility = Object.getOwnPropertyDescriptor(
+    Document.prototype,
+    'visibilityState'
+  );
+  const originalHasFocus = document.hasFocus;
+
+  function setVisibility(value: DocumentVisibilityState) {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => value,
+    });
+  }
+
+  function setHasFocus(value: boolean) {
+    document.hasFocus = () => value;
+  }
+
+  afterEach(() => {
+    if (originalVisibility) {
+      Object.defineProperty(Document.prototype, 'visibilityState', originalVisibility);
+    }
+    document.hasFocus = originalHasFocus;
+  });
+
+  it('reports the initial activity from document state', () => {
+    setVisibility('visible');
+    setHasFocus(true);
+
+    const { result } = renderHook(() => useDocumentActivity());
+
+    expect(result.current).toBe('active');
+  });
+
+  it('transitions to hidden when visibilitychange fires with hidden state', () => {
+    setVisibility('visible');
+    setHasFocus(true);
+
+    const { result } = renderHook(() => useDocumentActivity());
+    expect(result.current).toBe('active');
+
+    act(() => {
+      setVisibility('hidden');
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    expect(result.current).toBe('hidden');
+  });
+
+  it('transitions to idle when the window blurs', () => {
+    setVisibility('visible');
+    setHasFocus(true);
+
+    const { result } = renderHook(() => useDocumentActivity());
+    expect(result.current).toBe('active');
+
+    act(() => {
+      setHasFocus(false);
+      window.dispatchEvent(new Event('blur'));
+    });
+
+    expect(result.current).toBe('idle');
+  });
+
+  it('returns to active when focus is restored', () => {
+    setVisibility('visible');
+    setHasFocus(false);
+
+    const { result } = renderHook(() => useDocumentActivity());
+    expect(result.current).toBe('idle');
+
+    act(() => {
+      setHasFocus(true);
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    expect(result.current).toBe('active');
+  });
+});

--- a/src/shared/utils/useDocumentActivity.ts
+++ b/src/shared/utils/useDocumentActivity.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+export type DocumentActivity = 'active' | 'idle' | 'hidden';
+
+/**
+ * Classify the window's user-attention level from raw browser signals.
+ *
+ * - `hidden`: minimized, on another desktop, or behind a fullscreen app —
+ *   the WebView cannot paint to the user. Pause expensive work entirely.
+ * - `idle`: visible but unfocused (user is in another window). The audio
+ *   visualization is still on screen if the window peeks out, but the user
+ *   is not actively watching, so we can poll less aggressively.
+ * - `active`: the window has keyboard focus. Use the normal polling rate.
+ */
+export function detectActivity(
+  visibility: DocumentVisibilityState,
+  hasFocus: boolean
+): DocumentActivity {
+  if (visibility === 'hidden') return 'hidden';
+  if (!hasFocus) return 'idle';
+  return 'active';
+}
+
+/**
+ * React hook returning the current user-attention level. Re-renders on
+ * `visibilitychange` and window focus/blur events.
+ */
+export function useDocumentActivity(): DocumentActivity {
+  const [activity, setActivity] = useState<DocumentActivity>(() =>
+    detectActivity(document.visibilityState, document.hasFocus())
+  );
+
+  useEffect(() => {
+    const update = () => {
+      setActivity(detectActivity(document.visibilityState, document.hasFocus()));
+    };
+
+    document.addEventListener('visibilitychange', update);
+    window.addEventListener('focus', update);
+    window.addEventListener('blur', update);
+
+    return () => {
+      document.removeEventListener('visibilitychange', update);
+      window.removeEventListener('focus', update);
+      window.removeEventListener('blur', update);
+    };
+  }, []);
+
+  return activity;
+}


### PR DESCRIPTION
## Summary

- Renderer memory during recording dropped from ~640 MB to ~150 MB with ~1400 stored sessions.
- GPU 3D engine load on an idle NVIDIA 3080 fell from 12.6% to under 1% while recording.
- CPU usage during recording fell to under 1%; the audio-level visualizer no longer lags.
- Polling for audio levels and recording duration now backs off when the window is unfocused and stops entirely when the window is hidden.

## Root causes

This was fixed in three iterative passes, each verified by the user with Task Manager and DevTools paint flashing.

**Pass 1 — list-rendering blowup.** `SessionList` rendered every one of the ~1400 `SessionListItem` nodes, and the 10 Hz duration-polling timer in `useRecordingWorkflow` forced React to reconcile the entire list ten times per second during recording. `transition: all` on every list item amplified compositor cost by monitoring every animatable property on 1400 nodes.

**Pass 2 — continuously-promoted compositor layers.** The `btn-pulse` opacity animation on the Stop button kept a compositor layer painting at 60 Hz for the duration of every recording. Audio polling at 50 ms and duration polling at 100 ms produced more work than the UI ever displayed (the audio canvas updates at ~20 Hz, the MM:SS timer at 1 Hz). A leftover `will-change: transform` from pass 1 kept the virtualization window permanently layer-promoted.

**Pass 3 — visibility-aware polling.** With the previous passes applied, the audio canvas in `src/features/recording` was the only remaining continuous repainter. There was no reason for it to keep polling and painting when the window was minimized or alt-tabbed.

## Changes

- Added `src/features/sessions/useVirtualizedList.ts` (pure `computeVirtualRange` + a React hook layered on top) that windows the session list with overscan, RAF-throttled scroll, and a `ResizeObserver` for container resize.
- Rewrote `src/features/sessions/SessionList.tsx` to render only the visible slice inside a spacer/window pair, wrapped the component in `React.memo`.
- Wrapped `src/features/sessions/SessionListItem.tsx` in `React.memo` and changed its `onSelect` contract to `(id) => void` with a stable `useCallback` handler so the parent no longer passes a fresh arrow per item.
- `src/features/sessions/SessionListItem.css`: replaced `transition: all` with explicit `background-color` and `border-color` transitions.
- `src/features/sessions/SessionList.css`: added the `.session-list-virtual-spacer` / `.session-list-virtual-window` scaffolding.
- `src/features/recording/RecordingControls.tsx`: removed the `btn-pulse` class from the Stop button.
- Added `src/shared/utils/useDocumentActivity.ts` exposing a pure `detectActivity(visibility, hasFocus)` classifier and a `useDocumentActivity()` hook returning `'active' | 'idle' | 'hidden'` based on `document.visibilityState` and `document.hasFocus()`, listening to `visibilitychange`, `focus`, and `blur`.
- `src/features/recording/useAudioLevels.ts`: introduced `selectAudioLevelPollInterval` mapping `active -> 100 ms`, `idle -> 500 ms`, `hidden -> null` (no polling). Last audio levels remain in state while hidden so the canvas does not flash empty on un-hide.
- `src/app/useRecordingWorkflow.ts`: duration polling slowed from 100 ms to 500 ms (display granularity is whole seconds) and is now suspended entirely when `activity === 'hidden'`.
- Added unit tests for `computeVirtualRange`, `detectActivity`, `useDocumentActivity`, and `selectAudioLevelPollInterval`; extended `useAudioLevels` tests with hide/un-hide and blur-to-idle transitions; updated `useRecordingWorkflow` test for the 500 ms duration cadence.
