### PR TITLE
BUG: Fix CI build failures from Tauri CLI version validation

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,9 +21,9 @@ tauri-build = { version = "2.5.1", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.9.2", features = [] }
-tauri-plugin-log = "2"
-tauri-plugin-dialog = "2"
+tauri = { version = "2.11", features = [] }
+tauri-plugin-log = "2.0"
+tauri-plugin-dialog = "2.0"
 cpal = "0.15"
 hound = "3.5"
 chrono = { version = "0.4", features = ["serde"] }
@@ -32,4 +32,4 @@ arboard = "3.3"
 rodio = { version = "0.19", default-features = false, features = ["wav", "mp3", "vorbis", "flac"] }
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
-tauri-plugin-global-shortcut = "2"
+tauri-plugin-global-shortcut = "2.0"


### PR DESCRIPTION
## Summary

- Tauri CLI 2.9.2 (pulled fresh in CI) rejects bare major-version strings like `"2"` and flags any mismatch between the `tauri` literal in `Cargo.toml` and the resolved `@tauri-apps/api` npm package. Local builds passed only because a stale `node_modules` CLI had looser parsing.
- Bumped `tauri = "2.9.2"` to `tauri = "2.11"` so it matches `@tauri-apps/api` 2.11.0 in `package-lock.json`. `Cargo.lock` already resolved to 2.11.1 under the old caret, so no compiled behavior changes.
- Rewrote plugin constraints `"2"` to `"2.0"` for `tauri-plugin-log`, `tauri-plugin-dialog`, and `tauri-plugin-global-shortcut`. These are semver-equivalent (`^2.0`) but parseable by the stricter CLI; resolved versions in `Cargo.lock` are unchanged.

