### PR TITLE
BUG: Fix chunked transcript truncation and unfreeze retranscribe flow

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -196,8 +196,46 @@ fn copy_transcript_to_clipboard(session_id: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn retranscribe_session(session_id: String) -> Result<String, String> {
-    recording::retranscribe_session(&session_id)
+fn retranscribe_session(
+    state: State<AppState>,
+    app: tauri::AppHandle,
+    session_id: String,
+) -> Result<Session, String> {
+    let recording_state = Arc::clone(&state.inner().recording);
+
+    // Sync prep: mark the session as Processing... and return immediately so
+    // the UI can light up the existing transcribing view. Heavy lifting
+    // (decode + Whisper) runs on the background thread spawned below.
+    let session = recording::start_retranscription(&session_id)?;
+
+    recording::orchestrate_async_retranscription(
+        recording_state,
+        session_id,
+        move |result| match result {
+            TranscriptionResult::Success(updated_session) => {
+                let _ = app.emit(
+                    "transcription-complete",
+                    TranscriptionCompleteEvent {
+                        session: updated_session,
+                    },
+                );
+            }
+            TranscriptionResult::Progress(progress) => {
+                let _ = app.emit("transcription-progress", progress);
+            }
+            TranscriptionResult::Compressed(compression_event) => {
+                let _ = app.emit("session-audio-compressed", compression_event);
+            }
+            TranscriptionResult::Error { session_id, error } => {
+                let _ = app.emit(
+                    "transcription-error",
+                    TranscriptionErrorEvent { session_id, error },
+                );
+            }
+        },
+    );
+
+    Ok(session)
 }
 
 #[tauri::command]

--- a/src-tauri/src/recording/audio/capture.rs
+++ b/src-tauri/src/recording/audio/capture.rs
@@ -28,6 +28,9 @@ pub fn start_capture(state: SharedRecordingState) -> Result<(), String> {
     state_guard.pause_start_time = None;
     state_guard.total_paused_duration_ms = 0;
     state_guard.status = RecordingStatus::Recording;
+    // Clear any rate left over from a prior capture — the audio thread will
+    // populate it from the device's `default_input_config()` once it starts.
+    state_guard.sample_rate = None;
 
     // Clone references for the recording thread
     let samples_clone = Arc::clone(&state_guard.samples);
@@ -66,6 +69,17 @@ fn run_audio_capture_loop(
     let config = device
         .default_input_config()
         .map_err(|e| format!("Failed to get default input config: {}", e))?;
+
+    // Publish the device's sample rate so the WAV writer can label the file
+    // accurately. Without this, samples captured at the device's native rate
+    // (often 48 kHz) get labelled 44.1 kHz, time-stretching playback and
+    // pushing the audio's apparent tail past whatever duration the chunked
+    // transcription planner uses — meaning the last ~9% of the recording
+    // never gets transcribed.
+    let device_sample_rate = config.sample_rate().0;
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.sample_rate = Some(device_sample_rate);
+    }
 
     let samples_for_stream = Arc::clone(&samples);
     let state_for_stream = Arc::clone(&state);

--- a/src-tauri/src/recording/audio/mod.rs
+++ b/src-tauri/src/recording/audio/mod.rs
@@ -4,4 +4,4 @@ pub mod writer;
 
 pub use capture::start_capture;
 pub use level_calculator::get_audio_levels;
-pub use writer::write_wav_file;
+pub use writer::{read_wav_duration_seconds, write_wav_file};

--- a/src-tauri/src/recording/audio/writer.rs
+++ b/src-tauri/src/recording/audio/writer.rs
@@ -1,14 +1,20 @@
-use hound::{WavSpec, WavWriter};
+use hound::{WavReader, WavSpec, WavWriter};
 use std::path::Path;
 
-/// Write audio samples to a WAV file
+/// Write F32 audio samples to a 16-bit mono WAV file.
 ///
-/// Converts F32 samples to 16-bit signed integer format
-/// with 44.1kHz sample rate and mono channel
-pub fn write_wav_file(samples: &[f32], output_path: &Path) -> Result<(), String> {
+/// `sample_rate` MUST match the rate the samples were captured at — labelling
+/// the file with a different rate (e.g. hard-coding 44.1 kHz while CPAL
+/// captured at 48 kHz) time-stretches playback and silently truncates the
+/// chunked transcription's view of the audio.
+pub fn write_wav_file(
+    samples: &[f32],
+    output_path: &Path,
+    sample_rate: u32,
+) -> Result<(), String> {
     let spec = WavSpec {
         channels: 1,
-        sample_rate: 44100,
+        sample_rate,
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,
     };
@@ -29,4 +35,79 @@ pub fn write_wav_file(samples: &[f32], output_path: &Path) -> Result<(), String>
         .map_err(|e| format!("Failed to finalize WAV file: {}", e))?;
 
     Ok(())
+}
+
+/// Read the WAV header at `wav_path` and return its apparent playback duration
+/// in seconds (frames / sample_rate).
+///
+/// Used by retranscribe to drive chunk planning off the audio file's real
+/// timeline rather than the wall-clock `session.duration`. The two diverge
+/// for pre-fix recordings whose WAV/M4A headers were mislabelled.
+pub fn read_wav_duration_seconds(wav_path: &Path) -> Result<f64, String> {
+    let reader = WavReader::open(wav_path)
+        .map_err(|e| format!("Failed to open WAV at {}: {}", wav_path.display(), e))?;
+    let spec = reader.spec();
+    if spec.sample_rate == 0 {
+        return Err(format!(
+            "WAV header reports a zero sample rate at: {}",
+            wav_path.display()
+        ));
+    }
+    // `WavReader::duration()` is "samples per channel" — i.e. frames. Dividing
+    // by sample_rate gives wall-clock seconds of playback at the labelled rate.
+    let frames = reader.duration() as f64;
+    Ok(frames / spec.sample_rate as f64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("thoughtcast_writer_test_{}_{}.wav", std::process::id(), name));
+        p
+    }
+
+    #[test]
+    fn test_write_wav_file_records_passed_sample_rate_in_header() {
+        let path = temp_path("48k");
+        let samples = vec![0.0f32; 48_000]; // 1 second at 48 kHz
+        write_wav_file(&samples, &path, 48_000).expect("write should succeed");
+
+        let reader = WavReader::open(&path).expect("read should succeed");
+        let spec = reader.spec();
+        assert_eq!(spec.sample_rate, 48_000);
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.bits_per_sample, 16);
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_read_wav_duration_seconds_matches_sample_count_over_rate() {
+        let path = temp_path("48k_2s");
+        // 2 seconds of silence at 48 kHz → 96000 frames
+        let samples = vec![0.0f32; 96_000];
+        write_wav_file(&samples, &path, 48_000).expect("write should succeed");
+
+        let duration = read_wav_duration_seconds(&path).expect("read should succeed");
+        assert!(
+            (duration - 2.0).abs() < 0.001,
+            "expected ~2.0s, got {}",
+            duration
+        );
+
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_read_wav_duration_seconds_errors_on_missing_file() {
+        let err = read_wav_duration_seconds(Path::new(
+            "/definitely/does/not/exist/thoughtcast_missing.wav",
+        ))
+        .unwrap_err();
+        assert!(err.contains("Failed to open WAV"));
+    }
 }

--- a/src-tauri/src/recording/mod.rs
+++ b/src-tauri/src/recording/mod.rs
@@ -33,9 +33,9 @@ pub use compression::{
 
 // Session operations (main API surface)
 pub use session::{
-    cancel_recording, load_sessions, load_transcript, orchestrate_async_transcription,
-    pause_recording, resume_recording, retranscribe_session, start_recording, stop_recording,
-    TranscriptionResult,
+    cancel_recording, load_sessions, load_transcript, orchestrate_async_retranscription,
+    orchestrate_async_transcription, pause_recording, resume_recording, start_recording,
+    start_retranscription, stop_recording, TranscriptionResult,
 };
 
 // Utility functions

--- a/src-tauri/src/recording/session/lifecycle.rs
+++ b/src-tauri/src/recording/session/lifecycle.rs
@@ -1,14 +1,14 @@
-use crate::recording::audio::{start_capture, write_wav_file};
+use crate::recording::audio::{read_wav_duration_seconds, start_capture, write_wav_file};
 use crate::recording::compression::{run_post_transcription_compression, SessionAudioCompressedEvent};
 use crate::recording::models::{AppConfig, Session};
 use crate::recording::session::storage::add_session;
 use crate::recording::state::{RecordingStatus, SharedRecordingState};
 use crate::recording::transcription::{
-    transcribe_in_chunks, transcribe_with_whisper, ChunkingTelemetry,
+    decode_to_wav, transcribe_in_chunks, transcribe_with_whisper, ChunkingTelemetry,
 };
 use crate::recording::utils::{copy_to_clipboard, get_storage_dir};
 use chrono::Utc;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
@@ -420,6 +420,11 @@ fn calculate_duration(state: &crate::recording::state::RecordingState) -> f64 {
 }
 
 /// Save recorded audio samples to a WAV file
+///
+/// Uses the device-reported sample rate the audio thread published on the
+/// state. Falls back to 44.1 kHz only if the audio thread hasn't populated it
+/// — which would mean capture initialization failed, in which case the
+/// samples buffer is empty and the rate is irrelevant.
 fn save_audio_file(
     id: &str,
     state: &crate::recording::state::RecordingState,
@@ -428,9 +433,9 @@ fn save_audio_file(
     let audio_filename = format!("{}.wav", id);
     let audio_path = storage_dir.join("audio").join(&audio_filename);
 
-    // Copy samples from state
+    let sample_rate = state.sample_rate.unwrap_or(44_100);
     let samples = state.samples.lock().unwrap();
-    write_wav_file(&samples, &audio_path)?;
+    write_wav_file(&samples, &audio_path, sample_rate)?;
 
     Ok(audio_path)
 }
@@ -484,64 +489,159 @@ fn generate_preview(text: &str) -> String {
     }
 }
 
-/// Re-transcribe an existing audio session
+/// Mark a session as "in-flight" for re-transcription and return the updated
+/// session row.
 ///
-/// This will overwrite any existing transcript for this session
-pub fn retranscribe_session(session_id: &str) -> Result<String, String> {
+/// This is the synchronous half of the retranscribe workflow — the caller is
+/// expected to hand the returned session to the frontend immediately and then
+/// kick off `orchestrate_async_retranscription` to actually run Whisper on a
+/// background thread. Mirrors the `stop_recording` → `orchestrate_async_transcription`
+/// pattern so the UI's existing "Processing..." view can light up without any
+/// new frontend plumbing.
+pub fn start_retranscription(session_id: &str) -> Result<Session, String> {
     use crate::recording::session::storage::{load_sessions, save_sessions};
 
     let storage_dir = get_storage_dir()?;
-
-    // Load sessions to find the audio file
     let mut index = load_sessions()?;
 
-    // Find the session
     let session = index
         .sessions
         .iter_mut()
         .find(|s| s.id == session_id)
         .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
-    // Get the full path to the audio file
     let audio_path = storage_dir.join(&session.audio_path);
-
     if !audio_path.exists() {
         return Err(format!("Audio file not found: {}", audio_path.display()));
     }
 
-    // Get audio duration for metadata
-    let audio_duration = session.duration;
+    // The literal "Processing..." preview is what the SessionViewer keys off
+    // to render the spinner + estimated-time UI (see
+    // `determineTranscriptionState` on the frontend). Reusing the same marker
+    // means retranscribe gets the existing transcribing view for free.
+    session.preview = "Processing...".to_string();
+    let updated = session.clone();
 
+    save_sessions(&index)?;
+    Ok(updated)
+}
+
+/// Orchestrate async re-transcription in a background thread.
+///
+/// Mirrors `orchestrate_async_transcription`: spawns a worker, runs the
+/// retranscription pipeline, and emits the same `TranscriptionResult` events
+/// the initial-recording flow uses so the UI listeners already wired up in
+/// `useRecordingWorkflow` light up without any frontend-side changes.
+///
+/// Skips post-transcription compression — the session's source audio was
+/// already compressed (or never qualified), and re-compressing on every
+/// retranscribe would waste CPU and re-encode m4a → m4a.
+pub fn orchestrate_async_retranscription<F>(
+    state: SharedRecordingState,
+    session_id: String,
+    event_emitter: F,
+) where
+    F: Fn(TranscriptionResult) + Send + Sync + 'static,
+{
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.transcribing_session_ids.insert(session_id.clone());
+    }
+
+    thread::spawn(move || {
+        let emitter = Arc::new(event_emitter);
+        let progress_session_id = session_id.clone();
+        let progress_emitter = Arc::clone(&emitter);
+        let progress_fn = move |current: u32, total: u32| {
+            progress_emitter(TranscriptionResult::Progress(ChunkProgressEvent {
+                session_id: progress_session_id.clone(),
+                current,
+                total,
+            }));
+        };
+
+        let result = process_retranscription_async(session_id.clone(), &progress_fn);
+
+        if let Ok(mut state_guard) = state.lock() {
+            state_guard.transcribing_session_ids.remove(&session_id);
+        }
+
+        match result {
+            Ok(session) => emitter(TranscriptionResult::Success(session)),
+            Err(error) => emitter(TranscriptionResult::Error { session_id, error }),
+        }
+    });
+}
+
+/// Run the actual retranscription work: decode source audio if needed,
+/// transcribe, sync the session row's duration to the audio file's true
+/// playback duration, and persist the updated session.
+fn process_retranscription_async(
+    session_id: String,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> Result<Session, String> {
+    use crate::recording::session::storage::{load_sessions, save_sessions};
+
+    let storage_dir = get_storage_dir()?;
+    let mut index = load_sessions()?;
+    let session = index
+        .sessions
+        .iter_mut()
+        .find(|s| s.id == session_id)
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+    let audio_path = storage_dir.join(&session.audio_path);
+    if !audio_path.exists() {
+        return Err(format!("Audio file not found: {}", audio_path.display()));
+    }
+
+    let session_wall_clock_duration = session.duration;
     let config = crate::recording::load_config().ok();
-    let no_op_progress: &(dyn Fn(u32, u32) + Sync) = &|_, _| {};
+
+    let (transcription_input, temp_wav_to_cleanup) =
+        prepare_retranscribe_input(&audio_path, &session_id, config.as_ref())?;
+
+    // Drive chunking off the audio file's actual apparent duration. For
+    // pre-fix recordings the WAV/M4A header was labelled 44.1 kHz while
+    // CPAL captured at 48 kHz — making playback ~8.8% longer than
+    // `session.duration`. Using the file's own timeline ensures the planner
+    // covers every second of audio that ffmpeg will actually slice.
+    let chunking_duration =
+        chunking_duration_for(&transcription_input, session_wall_clock_duration);
 
     let transcription_start = Instant::now();
-    let (transcript_path, preview, _clipboard_copied, chunking_telemetry) =
+    let (transcript_path, preview, clipboard_copied, chunking_telemetry) =
         run_transcription_route(
-            &audio_path,
-            session_id,
-            audio_duration,
+            &transcription_input,
+            &session_id,
+            chunking_duration,
             config.as_ref(),
-            no_op_progress,
+            on_progress,
         );
     let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
 
-    // Reload transcript text from disk so the return matches the saved file
-    // exactly (whether single-shot or stitched-chunk output).
-    let transcript_text = if transcript_path.is_empty() {
+    if let Some(temp) = temp_wav_to_cleanup {
+        let _ = std::fs::remove_file(&temp);
+    }
+
+    if transcript_path.is_empty() {
         return Err(preview);
-    } else {
-        let abs_transcript = storage_dir.join(&transcript_path);
-        std::fs::read_to_string(&abs_transcript)
-            .map_err(|e| format!("Failed to read regenerated transcript: {}", e))?
-    };
+    }
 
     let model_path = config.as_ref().map(|c| c.model_path.clone());
 
     session.transcript_path = transcript_path.clone();
     session.preview = preview;
+    session.clipboard_copied = clipboard_copied;
 
-    if !transcript_path.is_empty() && audio_duration > 0.0 {
+    // Reconcile session.duration with the audio's actual playback length.
+    // Pre-fix recordings were stored with the wall-clock duration even though
+    // their WAV/M4A headers report a stretched timeline; without this update
+    // the UI keeps showing "17:21" for an 18:53 file forever.
+    if (chunking_duration - session_wall_clock_duration).abs() > 0.5 {
+        session.duration = chunking_duration;
+    }
+
+    if session_wall_clock_duration > 0.0 {
         session.transcription_time_seconds = Some(transcription_elapsed);
         session.model_path = model_path;
     }
@@ -551,7 +651,180 @@ pub fn retranscribe_session(session_id: &str) -> Result<String, String> {
         session.chunking_used_fallback = Some(telemetry.used_fallback);
     }
 
+    let updated = session.clone();
     save_sessions(&index)?;
+    Ok(updated)
+}
 
-    Ok(transcript_text)
+/// Resolve the WAV path to feed into the transcription route.
+///
+/// Returns `(input_for_whisper, optional_temp_to_clean_up)`. The second slot
+/// is `Some(path)` only when we created a temp WAV by decoding a compressed
+/// source, so the caller can remove it after transcription completes.
+///
+/// Failure here is fatal for the retranscribe — without WAV input the
+/// whisper.cpp call would fail anyway, and a meaningful FFmpeg error is far
+/// more diagnosable than the generic whisper failure that would follow.
+fn prepare_retranscribe_input(
+    audio_path: &Path,
+    session_id: &str,
+    config: Option<&AppConfig>,
+) -> Result<(PathBuf, Option<PathBuf>), String> {
+    if is_wav_path(audio_path) {
+        return Ok((audio_path.to_path_buf(), None));
+    }
+
+    let cfg = config.ok_or_else(|| {
+        "Cannot retranscribe compressed audio: app config could not be loaded \
+         (FFmpeg path is required to decode .m4a back to .wav)"
+            .to_string()
+    })?;
+
+    let temp_wav = derive_retranscribe_temp_path(audio_path, session_id);
+    decode_to_wav(&cfg.ffmpeg_path, audio_path, &temp_wav)?;
+    Ok((temp_wav.clone(), Some(temp_wav)))
+}
+
+/// True if `p` looks like a WAV file by extension. Whisper.cpp only accepts
+/// WAV, so anything else needs a decode step.
+fn is_wav_path(p: &Path) -> bool {
+    p.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("wav"))
+        .unwrap_or(false)
+}
+
+/// Co-locate the decoded WAV next to the compressed source so the chunk
+/// pipeline's per-chunk writes stay on the same volume (the chunked
+/// orchestrator does the same trick for its own workspace). The leading dot
+/// hides it from casual `ls`; the session id keeps concurrent retranscribes
+/// from colliding on the same path.
+fn derive_retranscribe_temp_path(audio_path: &Path, session_id: &str) -> PathBuf {
+    let parent = audio_path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(".retranscribe-{}.wav", session_id))
+}
+
+/// Pick the duration to feed into the chunking planner: the WAV's own
+/// apparent duration if we can read it, otherwise the session's wall-clock
+/// duration. Reading the header should never fail for a file we just
+/// produced (passthrough WAV or freshly-decoded temp), but the fallback
+/// keeps retranscribe from breaking if it does.
+fn chunking_duration_for(wav_path: &Path, session_duration: f64) -> f64 {
+    match read_wav_duration_seconds(wav_path) {
+        Ok(d) if d > 0.0 => d,
+        Ok(_) => session_duration,
+        Err(e) => {
+            log::warn!(
+                "Could not read WAV duration for {} ({}); falling back to session.duration={}",
+                wav_path.display(),
+                e,
+                session_duration
+            );
+            session_duration
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_wav_path_accepts_lowercase_wav() {
+        assert!(is_wav_path(Path::new("/x/y/recording.wav")));
+    }
+
+    #[test]
+    fn test_is_wav_path_accepts_mixed_case_wav() {
+        assert!(is_wav_path(Path::new("/x/y/recording.WAV")));
+        assert!(is_wav_path(Path::new("/x/y/recording.Wav")));
+    }
+
+    #[test]
+    fn test_is_wav_path_rejects_m4a() {
+        assert!(!is_wav_path(Path::new("/x/y/recording.m4a")));
+    }
+
+    #[test]
+    fn test_is_wav_path_rejects_mp3_and_extensionless() {
+        assert!(!is_wav_path(Path::new("/x/y/recording.mp3")));
+        assert!(!is_wav_path(Path::new("/x/y/recording")));
+    }
+
+    #[test]
+    fn test_derive_retranscribe_temp_path_uses_session_id_and_sibling_dir() {
+        let audio = Path::new("/data/audio/2026-05-14_20-06-16.m4a");
+        let temp = derive_retranscribe_temp_path(audio, "2026-05-14_20-06-16");
+        // Compare path components rather than full string so the test is
+        // platform-agnostic (Windows uses `\` separators).
+        assert_eq!(temp.parent(), audio.parent());
+        assert_eq!(
+            temp.file_name().and_then(|s| s.to_str()),
+            Some(".retranscribe-2026-05-14_20-06-16.wav")
+        );
+    }
+
+    #[test]
+    fn test_derive_retranscribe_temp_path_falls_back_to_cwd_when_no_parent() {
+        let audio = Path::new("recording.m4a");
+        let temp = derive_retranscribe_temp_path(audio, "abc");
+        // Either ".retranscribe-abc.wav" (no parent) or "./.retranscribe-abc.wav"
+        // — both are valid. We just want to confirm we didn't panic and the
+        // session id ended up in the filename.
+        let s = temp.to_string_lossy();
+        assert!(s.contains(".retranscribe-abc.wav"), "got: {}", s);
+    }
+
+    #[test]
+    fn test_prepare_retranscribe_input_passes_wav_through_without_temp() {
+        let audio = Path::new("/data/audio/2026-05-14_20-06-16.wav");
+        let (input, temp) = prepare_retranscribe_input(audio, "2026-05-14_20-06-16", None)
+            .expect("WAV passthrough should not require config");
+        assert_eq!(input, audio);
+        assert!(temp.is_none(), "no temp file should be created for WAV input");
+    }
+
+    #[test]
+    fn test_chunking_duration_for_falls_back_to_session_when_wav_missing() {
+        let missing = Path::new("/nope/does/not/exist.wav");
+        let duration = chunking_duration_for(missing, 123.4);
+        assert_eq!(duration, 123.4);
+    }
+
+    #[test]
+    fn test_chunking_duration_for_uses_wav_duration_when_readable() {
+        use crate::recording::audio::write_wav_file;
+
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "thoughtcast_lifecycle_test_{}.wav",
+            std::process::id()
+        ));
+
+        // 1 second of silence at 48 kHz — apparent duration should be 1.0s.
+        let samples = vec![0.0f32; 48_000];
+        write_wav_file(&samples, &path, 48_000).expect("write should succeed");
+
+        // session.duration intentionally wrong (mimics pre-fix mislabelling).
+        let duration = chunking_duration_for(&path, 0.918);
+        assert!(
+            (duration - 1.0).abs() < 0.001,
+            "expected ~1.0s from WAV header, got {}",
+            duration
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_prepare_retranscribe_input_requires_config_for_non_wav() {
+        let audio = Path::new("/data/audio/2026-05-14_20-06-16.m4a");
+        let err = prepare_retranscribe_input(audio, "2026-05-14_20-06-16", None)
+            .expect_err("non-WAV without config should fail");
+        assert!(
+            err.contains("FFmpeg path is required"),
+            "error should explain ffmpeg requirement, got: {}",
+            err
+        );
+    }
 }

--- a/src-tauri/src/recording/session/mod.rs
+++ b/src-tauri/src/recording/session/mod.rs
@@ -2,7 +2,8 @@ pub mod lifecycle;
 pub mod storage;
 
 pub use lifecycle::{
-    cancel_recording, orchestrate_async_transcription, pause_recording, resume_recording,
-    retranscribe_session, start_recording, stop_recording, TranscriptionResult,
+    cancel_recording, orchestrate_async_retranscription, orchestrate_async_transcription,
+    pause_recording, resume_recording, start_recording, start_retranscription, stop_recording,
+    TranscriptionResult,
 };
 pub use storage::{load_sessions, load_transcript};

--- a/src-tauri/src/recording/state.rs
+++ b/src-tauri/src/recording/state.rs
@@ -28,6 +28,13 @@ pub struct RecordingState {
     pub total_paused_duration_ms: i64,
     pub active_session_id: Option<String>,
     pub transcribing_session_ids: std::collections::HashSet<String>,
+    /// Device sample rate (Hz) for the current capture, populated by the audio
+    /// thread once it has queried the input device. The WAV writer reads this
+    /// at save time so the file's header matches the rate the samples were
+    /// actually captured at — labelling them 44.1 kHz when CPAL ran at 48 kHz
+    /// time-stretches playback by ~8.8% and silently truncates downstream
+    /// chunked transcription.
+    pub sample_rate: Option<u32>,
 }
 
 impl RecordingState {
@@ -40,6 +47,7 @@ impl RecordingState {
             total_paused_duration_ms: 0,
             active_session_id: None,
             transcribing_session_ids: std::collections::HashSet::new(),
+            sample_rate: None,
         }
     }
 

--- a/src-tauri/src/recording/transcription/audio_decoder.rs
+++ b/src-tauri/src/recording/transcription/audio_decoder.rs
@@ -1,0 +1,115 @@
+//! Decode an arbitrary audio file (e.g. M4A from post-transcription
+//! compression) to a temporary 16 kHz mono PCM WAV that whisper.cpp can
+//! consume directly. Used by the retranscribe path so a compressed session
+//! can be re-run through the same transcription flow — single-shot or
+//! chunked — as a fresh recording.
+
+use crate::recording::utils::apply_no_console_window;
+use std::path::Path;
+use std::process::Command;
+
+/// Decode `source` to a 16 kHz mono PCM WAV at `dest_wav` using FFmpeg.
+///
+/// The output format mirrors the recording pipeline (16 kHz mono PCM s16le)
+/// so the chunked path's per-chunk slice does not need to re-resample and
+/// whisper.cpp gets the format it expects without any further conversion.
+pub fn decode_to_wav(
+    ffmpeg_path: &str,
+    source: &Path,
+    dest_wav: &Path,
+) -> Result<(), String> {
+    if ffmpeg_path.trim().is_empty() {
+        return Err(
+            "FFmpeg path is not configured — cannot decode compressed audio for retranscription"
+                .to_string(),
+        );
+    }
+    if !Path::new(ffmpeg_path).exists() {
+        return Err(format!("FFmpeg binary not found at: {}", ffmpeg_path));
+    }
+    if !source.exists() {
+        return Err(format!("Source audio not found: {}", source.display()));
+    }
+
+    let output = build_decode_command(ffmpeg_path, source, dest_wav)
+        .output()
+        .map_err(|e| format!("Could not launch FFmpeg to decode audio: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("FFmpeg failed to decode audio: {}", stderr.trim()));
+    }
+
+    if !dest_wav.exists() {
+        return Err(format!(
+            "FFmpeg reported success but no decoded WAV was produced at: {}",
+            dest_wav.display()
+        ));
+    }
+
+    Ok(())
+}
+
+fn build_decode_command(ffmpeg_path: &str, source: &Path, dest_wav: &Path) -> Command {
+    let mut cmd = Command::new(ffmpeg_path);
+    cmd.arg("-y")
+        .arg("-hide_banner")
+        .arg("-loglevel")
+        .arg("error")
+        .arg("-i")
+        .arg(source)
+        .arg("-ar")
+        .arg("16000")
+        .arg("-ac")
+        .arg("1")
+        .arg("-c:a")
+        .arg("pcm_s16le")
+        .arg(dest_wav);
+
+    apply_no_console_window(&mut cmd);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_decode_returns_error_for_empty_ffmpeg_path() {
+        let src = PathBuf::from("/tmp/whatever.m4a");
+        let dst = PathBuf::from("/tmp/whatever.wav");
+        let err = decode_to_wav("", &src, &dst).unwrap_err();
+        assert!(err.contains("FFmpeg path is not configured"));
+    }
+
+    #[test]
+    fn test_decode_returns_error_for_nonexistent_ffmpeg_binary() {
+        let src = PathBuf::from("/tmp/whatever.m4a");
+        let dst = PathBuf::from("/tmp/whatever.wav");
+        let err = decode_to_wav("/definitely/missing/ffmpeg", &src, &dst).unwrap_err();
+        assert!(err.contains("FFmpeg binary not found"));
+    }
+
+    #[test]
+    fn test_build_decode_command_emits_pcm_16k_mono_args() {
+        let cmd = build_decode_command(
+            "/usr/bin/ffmpeg",
+            Path::new("/tmp/in.m4a"),
+            Path::new("/tmp/out.wav"),
+        );
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+
+        assert!(args.iter().any(|a| a == "16000"));
+        assert!(args.iter().any(|a| a == "pcm_s16le"));
+
+        let ac_idx = args.iter().position(|a| a == "-ac").expect("missing -ac");
+        assert_eq!(args[ac_idx + 1], "1");
+
+        let i_idx = args.iter().position(|a| a == "-i").expect("missing -i");
+        assert_eq!(args[i_idx + 1], "/tmp/in.m4a");
+    }
+}

--- a/src-tauri/src/recording/transcription/mod.rs
+++ b/src-tauri/src/recording/transcription/mod.rs
@@ -1,6 +1,8 @@
+pub mod audio_decoder;
 pub mod chunked_orchestrator;
 pub mod engine;
 pub mod text_processor;
 
+pub use audio_decoder::decode_to_wav;
 pub use chunked_orchestrator::{transcribe_in_chunks, ChunkingTelemetry};
 pub use engine::transcribe_with_whisper;

--- a/src/api/services/TranscriptService.test.ts
+++ b/src/api/services/TranscriptService.test.ts
@@ -119,15 +119,14 @@ describe('MockTranscriptService', () => {
   });
 
   describe('retranscribe', () => {
-    it('should return updated transcript', async () => {
-      const originalTranscript = await service.loadTranscript('2024-11-01_10-30-00');
-      const newTranscript = await service.retranscribe('2024-11-01_10-30-00');
+    it('should return a session row marked as in-flight', async () => {
+      const session = await service.retranscribe('2024-11-01_10-30-00');
 
-      expect(newTranscript).toContain('[Re-transcribed]');
-      expect(newTranscript).toContain(originalTranscript);
+      expect(session.id).toBe('2024-11-01_10-30-00');
+      expect(session.preview).toBe('Processing...');
     });
 
-    it('should update the stored transcript', async () => {
+    it('should pre-update the stored transcript so a later load reflects the new text', async () => {
       await service.retranscribe('2024-11-01_10-30-00');
       const updatedTranscript = await service.loadTranscript('2024-11-01_10-30-00');
 
@@ -139,14 +138,6 @@ describe('MockTranscriptService', () => {
       await expect(service.retranscribe('unknown-session')).rejects.toThrow(
         'Session not found for retranscription: unknown-session'
       );
-    });
-
-    it('should simulate longer async operation', async () => {
-      const start = Date.now();
-      await service.retranscribe('2024-11-01_10-30-00');
-      const duration = Date.now() - start;
-
-      expect(duration).toBeGreaterThanOrEqual(450); // ~500ms delay
     });
   });
 

--- a/src/api/services/TranscriptService.ts
+++ b/src/api/services/TranscriptService.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '..';
+import { ApiError, Session } from '..';
 import { wrapTauriInvoke } from './tauriInvokeWrapper';
 
 /**
@@ -14,12 +14,20 @@ export interface ITranscriptService {
   loadTranscript(sessionId: string): Promise<string>;
 
   /**
-   * Re-transcribe a session's audio file
+   * Kick off re-transcription of a session's audio file.
+   *
+   * Returns immediately with the session row marked `preview: "Processing..."`
+   * so the UI's existing transcribing view (the same one used after Stop
+   * Recording) can light up. The actual Whisper pass runs on a background
+   * thread and emits `transcription-complete` / `transcription-progress` /
+   * `transcription-error` Tauri events that `useRecordingWorkflow` already
+   * subscribes to.
+   *
    * @param sessionId - The unique session identifier
-   * @returns The new transcript text
-   * @throws {ApiError} If retranscription fails
+   * @returns The session row with its in-flight `preview` marker
+   * @throws {ApiError} If retranscription cannot be started (e.g. missing audio)
    */
-  retranscribe(sessionId: string): Promise<string>;
+  retranscribe(sessionId: string): Promise<Session>;
 }
 
 /**
@@ -37,8 +45,8 @@ export class TauriTranscriptService implements ITranscriptService {
     );
   }
 
-  async retranscribe(sessionId: string): Promise<string> {
-    return wrapTauriInvoke<string>(
+  async retranscribe(sessionId: string): Promise<Session> {
+    return wrapTauriInvoke<Session>(
       'retranscribe_session',
       { sessionId },
       `Failed to retranscribe session: ${sessionId}`,
@@ -78,9 +86,9 @@ export class MockTranscriptService implements ITranscriptService {
     return transcript;
   }
 
-  async retranscribe(sessionId: string): Promise<string> {
-    // Simulate longer async operation for transcription
-    await new Promise(resolve => setTimeout(resolve, 500));
+  async retranscribe(sessionId: string): Promise<Session> {
+    // Simulate the immediate-return contract of the real Tauri command.
+    await new Promise(resolve => setTimeout(resolve, 50));
 
     const existingTranscript = this.mockTranscripts.get(sessionId);
     if (!existingTranscript) {
@@ -91,11 +99,20 @@ export class MockTranscriptService implements ITranscriptService {
       );
     }
 
-    // Generate "updated" transcript
+    // Pre-update the mock so a later call to loadTranscript reflects the
+    // "re-transcribed" content. Real flow updates the file on disk before
+    // emitting `transcription-complete`.
     const newTranscript = `[Re-transcribed] ${existingTranscript}`;
     this.mockTranscripts.set(sessionId, newTranscript);
 
-    return newTranscript;
+    return {
+      id: sessionId,
+      preview: 'Processing...',
+      timestamp: new Date().toISOString(),
+      audio_path: `audio/${sessionId}.m4a`,
+      duration: 0,
+      transcript_path: `text/${sessionId}.txt`,
+    };
   }
 
   /**

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -36,6 +36,7 @@ function App() {
     handleResumeRecording,
     handleCancelRecording,
     handleStopRecording,
+    handleRetranscribe,
     setSelectedId,
     loadSessions,
   } = useRecordingWorkflow();
@@ -91,6 +92,7 @@ function App() {
         onResumeRecording={handleResumeRecording}
         onCancelRecording={handleCancelRecording}
         onStopRecording={handleStopRecording}
+        onRetranscribe={handleRetranscribe}
         onSessionsChanged={loadSessions}
       />
       <SettingsPanel

--- a/src/app/useRecordingWorkflow.ts
+++ b/src/app/useRecordingWorkflow.ts
@@ -130,6 +130,7 @@ interface RecordingWorkflowActions {
   handleResumeRecording: () => Promise<void>;
   handleCancelRecording: () => Promise<void>;
   handleStopRecording: () => Promise<void>;
+  handleRetranscribe: (sessionId: string) => Promise<void>;
   setSelectedId: (id: string | null) => void;
   loadSessions: () => Promise<void>;
 }
@@ -144,7 +145,7 @@ interface RecordingWorkflowActions {
  * - Status message management
  */
 export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkflowActions {
-  const { sessionService, recordingService } = useApi();
+  const { sessionService, recordingService, transcriptService } = useApi();
   const cues = useRecordingCues();
   const activity = useDocumentActivity();
   const [sessions, setSessions] = useState<Session[]>([]);
@@ -226,6 +227,31 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
       setStatus(`❌ Error: ${error}`);
     }
   }, [recordingService]);
+
+  const handleRetranscribe = useCallback(async (sessionId: string) => {
+    // Drive the existing top-bar transcribing UI by flipping the same flags
+    // `handleStopRecording` flips. The backend's async retranscribe pipeline
+    // emits the same `transcription-complete` / `-error` events as a fresh
+    // recording, so the existing event listeners (below) clear these flags
+    // automatically when the work finishes — no separate state machine.
+    try {
+      setRecordingStatus('processing');
+      setIsProcessing(true);
+      setStatus("🔄 Re-transcribing audio...");
+
+      await transcriptService.retranscribe(sessionId);
+
+      // Pick up the session row's `preview: "Processing..."` marker so the
+      // session list reflects the in-flight state immediately, instead of
+      // waiting for the next event to refresh it.
+      await loadSessions();
+    } catch (error) {
+      logger.error("Failed to start retranscription:", error);
+      setStatus(`❌ Error: ${error}`);
+      setRecordingStatus('idle');
+      setIsProcessing(false);
+    }
+  }, [transcriptService, loadSessions]);
 
   const handleStopRecording = useCallback(async () => {
     try {
@@ -358,6 +384,7 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
     handleResumeRecording,
     handleCancelRecording,
     handleStopRecording,
+    handleRetranscribe,
     setSelectedId,
     loadSessions,
   };

--- a/src/features/sessions/SessionViewer.tsx
+++ b/src/features/sessions/SessionViewer.tsx
@@ -3,12 +3,8 @@ import { formatTimestamp } from '../../shared/formatters/date-time';
 import { formatDuration } from '../../shared/formatters/duration';
 import { formatFilePath } from '../../shared/formatters/file-path';
 import RecordingControls from '../recording/RecordingControls';
-import { Button, Card, InfoRow, ProgressBar } from '../../shared/components';
+import { Button, Card, InfoRow } from '../../shared/components';
 import { useTranscriptViewer } from './useTranscriptViewer';
-import { useTranscriptionProgress } from '../transcription/useTranscriptionProgress';
-import { formatHumanReadableDuration } from '../transcription/formatHumanReadableDuration';
-import { prepareProgressDisplay } from '../transcription/prepareProgressDisplay';
-import { determineTranscriptionState } from '../transcription/determineTranscriptionState';
 import './SessionViewer.css';
 
 /**
@@ -47,6 +43,7 @@ interface SessionViewerProps {
   onResumeRecording: () => void;
   onCancelRecording: () => void;
   onStopRecording: () => void;
+  onRetranscribe: (sessionId: string) => Promise<void>;
   onSessionsChanged: () => Promise<void>;
 }
 
@@ -61,30 +58,23 @@ export default function SessionViewer({
   onResumeRecording,
   onCancelRecording,
   onStopRecording,
+  onRetranscribe,
   onSessionsChanged,
 }: SessionViewerProps) {
   const {
     transcript,
     transcriptError,
     isLoadingTranscript,
-    isRetranscribing,
     isCopying,
     copyButtonText,
     handleCopyToClipboard,
-    handleRetranscribe,
   } = useTranscriptViewer(selectedSession, onSessionsChanged);
 
-  // Determine transcription state and track progress
-  const transcriptionState = determineTranscriptionState(
-    selectedSession,
-    isProcessing,
-    recordingDuration
-  );
-  const progress = useTranscriptionProgress(
-    transcriptionState.isTranscribing,
-    transcriptionState.audioDurationSeconds
-  );
-  const displayData = prepareProgressDisplay(progress, formatHumanReadableDuration);
+  const handleRetranscribeClick = () => {
+    if (selectedSession) {
+      void onRetranscribe(selectedSession.id);
+    }
+  };
 
   return (
     <div className="session-viewer">
@@ -144,10 +134,10 @@ export default function SessionViewer({
               )}
               <Button
                 variant="success"
-                onClick={handleRetranscribe}
-                disabled={isRetranscribing}
+                onClick={handleRetranscribeClick}
+                disabled={isProcessing || !selectedSession}
               >
-                {isRetranscribing ? "Re-transcribing..." : "Re-transcribe"}
+                Re-transcribe
               </Button>
             </div>
 
@@ -163,41 +153,6 @@ export default function SessionViewer({
                 </div>
               ) : transcript && transcript.length > 0 ? (
                 <div className="transcript-text">{transcript}</div>
-              ) : selectedSession.preview === 'Processing...' ? (
-                <div className="transcript-text transcript-processing">
-                  <span className="processing-icon">⟳</span>
-                  <div className="transcription-status">
-                    {displayData.shouldDisplay ? (
-                      <>
-                        <span>
-                          Transcribing...
-                          {displayData.chunkLabel && (
-                            <> {displayData.chunkLabel}</>
-                          )}
-                          {displayData.estimatedText && (
-                            <> {displayData.estimatedText} estimated</>
-                          )}
-                        </span>
-                        {displayData.remainingText && (
-                          <span className="remaining-estimate">
-                            {displayData.remainingText}
-                          </span>
-                        )}
-                        <ProgressBar
-                          percent={displayData.progressPercent}
-                          height={6}
-                          className="session-progress-bar"
-                        />
-                      </>
-                    ) : (
-                      <span>Transcription in progress...</span>
-                    )}
-                    <p className="processing-hint">
-                      The audio has been saved. Whisper is transcribing in the
-                      background.
-                    </p>
-                  </div>
-                </div>
               ) : (
                 <div className="transcript-text no-transcript">
                   {selectedSession.preview || "No transcript available"}

--- a/src/features/sessions/useTranscriptViewer.test.ts
+++ b/src/features/sessions/useTranscriptViewer.test.ts
@@ -166,7 +166,6 @@ describe('useTranscriptViewer', () => {
     expect(result.current.transcript).toBeNull();
     expect(result.current.transcriptError).toBeNull();
     expect(result.current.isLoadingTranscript).toBe(false);
-    expect(result.current.isRetranscribing).toBe(false);
     expect(result.current.isCopying).toBe(false);
     expect(result.current.copyButtonText).toBe('Copy to Clipboard');
   });
@@ -339,94 +338,32 @@ describe('useTranscriptViewer', () => {
     expect(mockClipboardService.copyTranscriptToClipboard).not.toHaveBeenCalled();
   });
 
-  it('should retranscribe successfully', async () => {
-    mockTranscriptService.loadTranscript.mockResolvedValue('Original transcript');
-    mockTranscriptService.retranscribe.mockResolvedValue('New transcript');
+  it('should reload transcript when session preview changes (e.g. after retranscribe)', async () => {
+    mockTranscriptService.loadTranscript.mockResolvedValueOnce('Original transcript');
 
-    const { result } = renderHook(
-      () => useTranscriptViewer(sessionWithTranscript, mockOnSessionsChanged),
-      { wrapper }
+    const { result, rerender } = renderHook(
+      ({ session }: { session: Session | null }) =>
+        useTranscriptViewer(session, mockOnSessionsChanged),
+      { wrapper, initialProps: { session: sessionWithTranscript } }
     );
 
     await waitFor(() => {
       expect(result.current.transcript).toBe('Original transcript');
     }, { timeout: 10000 });
 
-    await act(async () => {
-      await result.current.handleRetranscribe();
-    });
-
-    expect(mockTranscriptService.retranscribe).toHaveBeenCalledWith('session-1');
-    expect(result.current.transcript).toBe('New transcript');
-    expect(mockOnSessionsChanged).toHaveBeenCalled();
-    expect(result.current.isRetranscribing).toBe(false);
-    expect(result.current.isLoadingTranscript).toBe(false);
-  });
-
-  it('should handle retranscribe error', async () => {
-    mockTranscriptService.loadTranscript.mockResolvedValue('Original transcript');
-    mockTranscriptService.retranscribe.mockRejectedValue(new Error('Retranscribe failed'));
-
-    const { result } = renderHook(
-      () => useTranscriptViewer(sessionWithTranscript, mockOnSessionsChanged),
-      { wrapper }
-    );
-
-    await waitFor(() => {
-      expect(result.current.transcript).toBe('Original transcript');
-    }, { timeout: 10000 });
-
-    await act(async () => {
-      await result.current.handleRetranscribe();
-    });
-
-    expect(result.current.transcript).toBeNull();
-    expect(result.current.transcriptError).toBe('Retranscription failed: Retranscribe failed');
-    expect(result.current.isRetranscribing).toBe(false);
-    expect(result.current.isLoadingTranscript).toBe(false);
-  });
-
-  it('should not retranscribe if no session selected', async () => {
-    const { result } = renderHook(
-      () => useTranscriptViewer(null, mockOnSessionsChanged),
-      { wrapper }
-    );
-
-    await act(async () => {
-      await result.current.handleRetranscribe();
-    });
-
-    expect(mockTranscriptService.retranscribe).not.toHaveBeenCalled();
-  });
-
-  it('should set loading states during retranscribe', async () => {
-    mockTranscriptService.loadTranscript.mockResolvedValue('Original transcript');
-    mockTranscriptService.retranscribe.mockImplementation(
-      () => new Promise((resolve) => setTimeout(() => resolve('New transcript'), 100))
-    );
-
-    const { result } = renderHook(
-      () => useTranscriptViewer(sessionWithTranscript, mockOnSessionsChanged),
-      { wrapper }
-    );
-
-    await waitFor(() => {
-      expect(result.current.transcript).toBe('Original transcript');
-    }, { timeout: 10000 });
-
-    act(() => {
-      result.current.handleRetranscribe();
+    // Simulate the post-retranscribe state: same id/transcript_path, but
+    // the preview flipped to the new prefix. The hook should refetch the
+    // transcript file rather than keep showing the stale loaded string.
+    mockTranscriptService.loadTranscript.mockResolvedValueOnce('Updated transcript');
+    rerender({
+      session: { ...sessionWithTranscript, preview: 'Updated transcript prefix...' },
     });
 
     await waitFor(() => {
-      expect(result.current.isRetranscribing).toBe(true);
-      expect(result.current.isLoadingTranscript).toBe(true);
+      expect(result.current.transcript).toBe('Updated transcript');
     }, { timeout: 10000 });
 
-    await waitFor(() => {
-      expect(result.current.isRetranscribing).toBe(false);
-      expect(result.current.isLoadingTranscript).toBe(false);
-    }, { timeout: 10000 });
+    expect(mockTranscriptService.loadTranscript).toHaveBeenCalledTimes(2);
   });
 
   it('should track copying state', async () => {

--- a/src/features/sessions/useTranscriptViewer.ts
+++ b/src/features/sessions/useTranscriptViewer.ts
@@ -20,38 +20,53 @@ interface TranscriptViewerState {
   transcript: string | null;
   transcriptError: string | null;
   isLoadingTranscript: boolean;
-  isRetranscribing: boolean;
   isCopying: boolean;
   copyButtonText: string;
 }
 
 interface TranscriptViewerActions {
   handleCopyToClipboard: () => Promise<void>;
-  handleRetranscribe: () => Promise<void>;
 }
 
 /**
  * Custom hook managing transcript viewing and operations
  *
  * Orchestrates:
- * - Transcript loading when session changes
- * - Retranscription workflow
+ * - Transcript loading when session changes (or its content changes)
  * - Clipboard copy with feedback
+ *
+ * Retranscription itself lives in `useRecordingWorkflow` so it can drive the
+ * top-bar "Transcribing..." UI through the same `isProcessing` flag the
+ * stop-recording flow uses.
  */
 export function useTranscriptViewer(
   selectedSession: Session | null,
-  onSessionsChanged: () => Promise<void>
+  _onSessionsChanged: () => Promise<void>
 ): TranscriptViewerState & TranscriptViewerActions {
   const { transcriptService, clipboardService } = useApi();
   const [transcript, setTranscript] = useState<string | null>(null);
   const [transcriptError, setTranscriptError] = useState<string | null>(null);
   const [isLoadingTranscript, setIsLoadingTranscript] = useState(false);
-  const [isRetranscribing, setIsRetranscribing] = useState(false);
   const [isCopying, setIsCopying] = useState(false);
   const [copyButtonText, setCopyButtonText] = useState("Copy to Clipboard");
 
-  // Load transcript when selected session changes
+  // Reload the transcript when the session changes OR when its content
+  // changes underneath us. The third dep — `preview` — is what catches a
+  // completed retranscription: the transcript file path stays the same
+  // (text/<session_id>.txt) but its bytes change, and the session row's
+  // preview flips from "Processing..." to a fresh prefix of the new text.
+  // Without that dep the transcript pane keeps showing the stale loaded
+  // string until the user navigates away and back.
+  //
+  // The `cancelled` guard handles a real race: this effect fires both when
+  // preview flips into "Processing..." and again when it flips out. The
+  // first run's in-flight `loadTranscript` would otherwise resolve LAST with
+  // the stale file contents (Whisper hadn't rewritten the file yet), stomping
+  // the second run's correct read. Bailing on stale runs keeps the freshest
+  // load authoritative.
   useEffect(() => {
+    let cancelled = false;
+
     const loadTranscript = async () => {
       if (!selectedSession) {
         setTranscript(null);
@@ -59,7 +74,15 @@ export function useTranscriptViewer(
         return;
       }
 
-      // Check if transcript is available
+      // Re-transcription is in flight — show the "Transcribing..." view
+      // (gated on `transcript` being empty in SessionViewer) and don't read
+      // the file yet: it still has the OLD content until Whisper rewrites it.
+      if (selectedSession.preview === 'Processing...') {
+        setTranscript(null);
+        setTranscriptError(null);
+        return;
+      }
+
       if (!hasTranscript(selectedSession)) {
         setTranscript(null);
         setTranscriptError("No transcript available");
@@ -71,18 +94,29 @@ export function useTranscriptViewer(
 
       try {
         const text = await transcriptService.loadTranscript(selectedSession.id);
+        if (cancelled) return;
         setTranscript(text);
       } catch (error) {
+        if (cancelled) return;
         logger.error("Failed to load transcript:", error);
         setTranscriptError(formatErrorMessage(error));
         setTranscript(null);
       } finally {
-        setIsLoadingTranscript(false);
+        if (!cancelled) setIsLoadingTranscript(false);
       }
     };
 
     loadTranscript();
-  }, [selectedSession?.id, selectedSession?.transcript_path, transcriptService]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    selectedSession?.id,
+    selectedSession?.transcript_path,
+    selectedSession?.preview,
+    transcriptService,
+  ]);
 
   const handleCopyToClipboard = useCallback(async () => {
     if (!selectedSession) return;
@@ -100,37 +134,12 @@ export function useTranscriptViewer(
     }
   }, [selectedSession, clipboardService]);
 
-  const handleRetranscribe = useCallback(async () => {
-    if (!selectedSession) return;
-
-    setIsRetranscribing(true);
-    setIsLoadingTranscript(true);
-    setTranscriptError(null);
-
-    try {
-      const newTranscript = await transcriptService.retranscribe(selectedSession.id);
-      setTranscript(newTranscript);
-
-      // Refresh the session list to get updated preview and transcript_path
-      await onSessionsChanged();
-    } catch (error) {
-      logger.error("Failed to retranscribe:", error);
-      setTranscriptError(`Retranscription failed: ${formatErrorMessage(error)}`);
-      setTranscript(null);
-    } finally {
-      setIsRetranscribing(false);
-      setIsLoadingTranscript(false);
-    }
-  }, [selectedSession, transcriptService, onSessionsChanged]);
-
   return {
     transcript,
     transcriptError,
     isLoadingTranscript,
-    isRetranscribing,
     isCopying,
     copyButtonText,
     handleCopyToClipboard,
-    handleRetranscribe,
   };
 }


### PR DESCRIPTION
## Summary

- Long recordings (7+ minutes) no longer lose the final ~9% of their transcript; a 17-minute session that previously cut off around 17:21 now transcribes to the end.
- Re-transcribing a session no longer freezes the app — the top-bar "Transcribing..." indicator appears immediately and the transcript pane refreshes automatically when it finishes.
- Re-transcribing short compressed (.m4a) sessions now works instead of silently failing.

## Implementation Notes

**Bug 1 — Sample rate mismatch (transcript truncation)**
- `src-tauri/src/recording/audio/writer.rs`: `write_wav_file` now takes an explicit `sample_rate: u32` instead of hardcoding 44100. Added `read_wav_duration_seconds` (uses `hound::WavReader`) for reading the file's apparent duration.
- `src-tauri/src/recording/audio/capture.rs` + `state.rs`: capture publishes the device's native sample rate into a new `RecordingState.sample_rate: Option<u32>` field, which is threaded through to the writer.
- `src-tauri/src/recording/session/lifecycle.rs`: retranscribe's chunk planner uses `chunking_duration_for(audio_path)` (the file's real duration via `read_wav_duration_seconds`) rather than `session.duration`, so pre-fix recordings with bad stored durations still get fully covered. `session.duration` is then updated to match.

**Bug 2 — Non-WAV input for short retranscribes**
- New `src-tauri/src/recording/transcription/audio_decoder.rs`: `decode_to_wav` shells out to ffmpeg, producing a 16 kHz mono PCM WAV in a temp path.
- `prepare_retranscribe_input` / `is_wav_path` / `derive_retranscribe_temp_path` detect non-WAV inputs, build a temp WAV, and the orchestrator removes it after transcription completes (success or failure).

**UX — Async retranscribe**
- `src-tauri/src/lib.rs`: `retranscribe_session` command is now async, returns the session immediately after marking `preview = "Processing..."`.
- `src-tauri/src/recording/session/lifecycle.rs`: split into `start_retranscription` (sync prep), `orchestrate_async_retranscription` (spawns worker), and `process_retranscription_async` (heavy lifting). Emits the same `transcription-complete` / `transcription-progress` / `transcription-error` events as a fresh recording, so the existing top-bar listener works unchanged.
- `src/api/services/TranscriptService.ts`: `retranscribe` now returns `Promise<Session>`.
- `src/app/useRecordingWorkflow.ts` + `src/app/App.tsx`: new `handleRetranscribe` lives alongside the other workflow handlers, flipping the same `isProcessing` flag `RecordingControls` already watches. Single source of truth for the transcribing UI is the top bar.
- `src/features/sessions/SessionViewer.tsx`: removed the in-pane "transcribing" block and its imports; the pane just shows the literal "Processing..." preview text from the session.
- `src/features/sessions/useTranscriptViewer.ts`: removed `handleRetranscribe` / `isRetranscribing`; transcript-reload effect now depends on `selectedSession.preview` (with a cancellation guard) so it refreshes the instant retranscribe completes.
