### PR TITLE
BUG: Stop caching ~/.cargo/bin/ in release workflow

### DIFF
--- a/.github/workflows/release-cross-platform.yml
+++ b/.github/workflows/release-cross-platform.yml
@@ -51,14 +51,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src-tauri/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-v2-
 
       - name: Install dependencies
         run: npm install
@@ -104,14 +103,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             src-tauri/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-v2-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-v2-
 
       - name: Install dependencies
         run: npm install

--- a/docs/PRD-bundle-transcription-dependencies-v2.md
+++ b/docs/PRD-bundle-transcription-dependencies-v2.md
@@ -1,0 +1,187 @@
+# PRD: Install and Go — Self-Contained Transcription
+
+## Problem Statement
+
+ThoughtCast records voice and transcribes it locally, but today none of that works after a fresh install. Before the app can do anything useful, a user has to compile Whisper.cpp from source, install FFmpeg, download a multi-gigabyte Whisper model, then hand-edit a `config.json` to point at all three. That is a "follow a setup guide for 30 minutes" experience standing between launch and the first transcription.
+
+This is fine on my one dev workstation. It falls apart the moment I want to use ThoughtCast on a second machine or treat this as a real release artifact. The friction lives in exactly the place a user can't bypass — there is no recording without the binaries, and no transcription without the model.
+
+I also have a related, pre-existing problem with storage. I currently dump everything (recordings, models, config) into `Documents/ThoughtCast/` because it's the only path I know about. Recordings belong there — the user wants to find them — but binaries and models belong somewhere the user isn't poking around in.
+
+Scope: this update bundles Whisper.cpp (the transcription engine) and the model-download flow. It deliberately does **not** bundle FFmpeg. Trying to ship an LGPL-clean macOS arm64 FFmpeg build turned out to be a real swamp — there is no FFmpeg-project-sanctioned arm64 binary, every community redistribution I looked at (martin-riedl, etc.) ships a GPL build by default, and the LGPL-clean path collapses to "build it ourselves in CI." Not worth the complexity for an app that's mostly used by me on machines where I already have FFmpeg installed. FFmpeg stays a user-installed prerequisite with clear in-app guidance when it's missing.
+
+I want the design to also leave the door open for adding a second transcription engine (NVIDIA Parakeet) later without redoing this work.
+
+## User Experience Goals
+
+**Current Behavior (Problematic)**:
+1. User downloads the installer, runs it, launches the app.
+2. App can't transcribe — config is missing. User digs through README, compiles Whisper.cpp from source, installs FFmpeg, downloads a model, edits `config.json` by hand.
+3. User abandons or successfully reaches step 2 after roughly half an hour.
+
+**Desired Behavior**:
+1. User downloads the installer, runs it, launches the app.
+2. App walks the user through the remaining setup: pick a Whisper model (downloaded in-app with progress), and confirm FFmpeg is installed (the app detects it on `PATH` first, and falls back to a one-screen install guide with OS-specific instructions if it's not found).
+3. User records something and it transcribes. Total hands-on time: a few minutes, plus model download time.
+
+**Key Requirements**:
+- The release installer ships with Whisper.cpp inside it. The user never installs or locates the `whisper-cli` binary.
+- First launch with no model triggers a single, clear prompt to pick one and downloads it for the user.
+- FFmpeg is detected from the system `PATH` or a configured override path. If missing, the user sees a focused install-instructions screen rather than a silent failure mid-transcription.
+- Recordings and transcripts continue to live in the user's `Documents` folder, where they can be found, backed up, and shared. App-managed files (Whisper.cpp binary, models) live somewhere the user isn't expected to touch.
+- Settings shows the user what version of Whisper.cpp is currently bundled, what FFmpeg version was detected (or "not found"), and what model is in use.
+- A path to a second transcription engine (Parakeet) is preserved — the directory layout and the engine/model selector UI in v1 must absorb it without redesign.
+- My existing dev `config.json` with hand-coded paths keeps working as an advanced override, so I'm not the casualty of my own release.
+
+## User Scenarios
+
+### Scenario 1: Fresh Install on a Machine That Already Has FFmpeg
+I move to a new laptop where I already have FFmpeg available on `PATH` (the common case for me — Homebrew on macOS, scoop or chocolatey on Windows). I download the latest installer, run it, launch ThoughtCast. The app picks up FFmpeg silently, notices I have no Whisper model, and opens a one-screen model picker. I pick one, watch a progress bar, and within a few minutes I'm transcribing. I never opened a terminal or edited a config file.
+
+### Scenario 2: Fresh Install Without FFmpeg
+I install ThoughtCast on a machine that doesn't have FFmpeg. The app launches, doesn't find FFmpeg anywhere, and shows a focused screen: "ThoughtCast uses FFmpeg to compress and chunk recordings. We don't bundle it because of FFmpeg's licensing model — but it's a one-line install." Below that: OS-specific commands (`brew install ffmpeg` on macOS, `winget install Gyan.FFmpeg` or `scoop install ffmpeg` on Windows). After I install it, ThoughtCast either auto-detects on next launch or I point it at the binary with a file picker. Recording and transcription work either way; compression and long-recording features are gated on FFmpeg being present.
+
+### Scenario 3: Curious About the New Engine
+A few releases in, Parakeet has been added as a second engine. I open Settings → Transcription, see two engines listed (Whisper.cpp and Parakeet), each with their own model picker. I switch to Parakeet to compare speed against my current Whisper setup. The engine selector and model selector are clearly distinct — choosing an engine doesn't silently invalidate my Whisper model, and switching back keeps my previous selection intact.
+
+### Scenario 4: I'm Still on My Dev Box
+On my development machine I have a hand-tuned Whisper.cpp build (GPU-enabled, custom compile flags) at a known path. My existing `config.json` has `whisperPath` and `ffmpegPath` pointing at my local installs. After upgrading to the bundled-Whisper release, ThoughtCast detects my Whisper override and keeps using my local build instead of the bundled one. My FFmpeg override continues to work as before. The bundled Whisper binary is a safety net; it doesn't replace what I've intentionally configured.
+
+## Edge Cases to Consider
+
+1. **First launch, no internet**: The bundled Whisper binary works without a network, but the model still needs downloading. User should see a clear "you'll need internet for the first model download" message rather than a generic connection error mid-download. If they dismiss the prompt and reopen the app offline, the prompt comes back next launch — recording is disabled until a model is present.
+
+2. **Model download interrupted**: User closes the laptop lid, kills the app, or loses Wi-Fi at 60% of a multi-hundred-MB download. Next launch, the partial file is detected and the user is offered "Resume download" rather than starting over from zero.
+
+3. **User picks a model, then deletes the file on disk**: Either by hand or via a "manage downloaded models" action. The next recording attempt should not crash — it should send them back to the model picker with a "the selected model is missing" note.
+
+4. **User has an existing model file from another tool**: They have a `ggml-base.bin` on disk from some other project. The model picker should offer "Use an existing file" as an alternative to downloading, and accept their pre-existing `.bin` after a quick sanity check.
+
+5. **FFmpeg is missing or stops being available**: User uninstalls FFmpeg, or it disappears from `PATH` between sessions. Transcription of short recordings keeps working (Whisper handles WAV directly); compression and long-recording chunking gracefully degrade with a clear "FFmpeg not found — here's how to install it" message rather than a silent crash mid-pipeline.
+
+6. **User without admin rights on Windows**: The NSIS installer's default install path is `C:\Program Files\ThoughtCast\`. If the user can't write there, they need a clear error or a per-user install option — not a silent failure that leaves the bundled Whisper binary unreachable.
+
+7. **Override path set in `config.json` points at a binary that no longer exists**: User had a path to a Whisper.cpp build they've since deleted. The resolver should fall back to the bundled binary with a one-time notice, rather than failing transcription.
+
+8. **Disk full mid-download**: User's drive runs out of space at 90%. The app should clean up the partial file (or leave a `.partial` and surface the failure clearly), free space if possible, and not corrupt the existing model selection.
+
+## What Users Should See
+
+**First-Run Model Picker (mandatory one-time step)**:
+```
+ThoughtCast is almost ready
+
+To transcribe recordings, choose a speech model. Models stay on
+your computer — nothing leaves your machine.
+
+  (   ) Whisper Tiny                75 MB
+  (   ) Whisper Base               142 MB
+  (   ) Whisper Small              466 MB
+  (   ) Whisper Medium             1.5 GB
+  ( o ) Whisper Large v3 Turbo     1.5 GB
+  (   ) Whisper Large v3           2.9 GB
+  (   ) I already have a .bin file  [Browse...]
+
+                                           [ Download model ]
+```
+
+**Model download in progress**:
+```
+Downloading Whisper Large v3 Turbo
+[##############---------] 62%   942 MB of 1.5 GB
+                          ~3 min remaining
+                                            [ Cancel ]
+```
+
+**Settings → Transcription tab**:
+```
+Engine:    [ Whisper.cpp           v ]
+
+Model:     Whisper Large v3 Turbo
+           1.5 GB · in use
+                                          [ Change model... ]
+
+Available models:
+  - Whisper Tiny               75 MB    [ Download ]
+  - Whisper Base               142 MB   [ Download ]
+  - Whisper Small              466 MB   [ Download ]
+  - Whisper Medium             1.5 GB   [ Download ]
+  - Whisper Large v3 Turbo     1.5 GB   ✓ downloaded
+  - Whisper Large v3           2.9 GB   [ Download ]
+
+Bundled engine:  Whisper.cpp 1.7.4
+
+Advanced: [ Use a custom Whisper CLI path... ]
+```
+
+**Settings → Compression tab (FFmpeg)**:
+```
+FFmpeg:    /usr/local/bin/ffmpeg
+           Detected version 7.0.2
+                                          [ Change path... ]
+
+(or, if missing:)
+
+FFmpeg:    ⚠ Not found
+           ThoughtCast needs FFmpeg for audio compression
+           and to chunk long recordings.
+
+           macOS:    brew install ffmpeg
+           Windows:  winget install Gyan.FFmpeg
+                                          [ I have it installed — pick the file ]
+```
+
+**About / version info display**:
+```
+ThoughtCast 0.5.0
+
+Built-in engine:
+  Whisper.cpp     1.7.4
+
+External tool:
+  FFmpeg          7.0.2 (detected at /usr/local/bin/ffmpeg)
+
+Active transcription model:
+  ggml-large-v3-turbo.bin  (Whisper Large v3 Turbo)
+
+Recordings are saved to:  ~/Documents/ThoughtCast/
+Models are managed in:    (app data folder)
+```
+
+## Success Criteria
+
+From the user's perspective:
+- A new user with FFmpeg already on `PATH` installs ThoughtCast, clicks through one model-picker prompt, and produces their first transcription without touching a terminal or a config file.
+- A new user without FFmpeg sees a clear, OS-specific install screen — not a stack trace and not a silent failure.
+- The first-run model download is visible (progress, ETA), cancelable, and resumable.
+- Recordings and transcripts stay in `Documents/ThoughtCast/` where the user expects to find them; the user does not have to know about or visit the app-managed folder where models live.
+- Settings clearly shows which Whisper model is in use, which Whisper.cpp version is bundled, and which FFmpeg version is detected (or that FFmpeg is missing).
+- A user who already had ThoughtCast configured manually (me on my dev box) keeps working without intervention after the upgrade.
+
+## Out of Scope
+
+- **Bundling FFmpeg** → Deliberately excluded. The macOS arm64 LGPL story is a swamp: no FFmpeg-project-sanctioned arm64 build, every prominent community redistribution (e.g. martin-riedl.de) ships a GPL build by default with `libx264`/`libx265` enabled, and the LGPL-clean path collapses to building it ourselves in CI. Not worth the complexity for an app I'm the primary user of and where I already have FFmpeg installed everywhere I care about. FFmpeg stays a user-installed prerequisite with in-app install guidance.
+- **NVIDIA Parakeet engine (v1)** → Future Extension. The directory layout and engine selector accommodate it; the integration itself is a follow-up release.
+- **Bundling Whisper model weights into the installer** → Models stay user-downloaded. They are 75 MB – 2.9 GB and would inflate the installer disproportionately.
+- **Override migration / config rewriting on upgrade** → I'm the only existing user, my override keeps working, no migration needed.
+- **macOS code signing and notarization** → Deferred until there's an audience that warrants the Apple Developer fee. Users will continue to right-click → Open on first launch.
+- **Linux builds and Intel macOS builds** → Matches the current release matrix (Windows x64, macOS arm64 only).
+- **GPU / CUDA Whisper builds** → Bundle CPU-only `whisper-cli` on both platforms. Users with GPU setups continue to use the override path.
+- **In-app auto-update of the bundled Whisper.cpp binary** → A new bundled version ships as part of a new ThoughtCast release, not as a separate update.
+- **Search / management of downloaded models** beyond the picker → A dedicated "downloaded models" manager with size totals, last-used dates, and a "remove" action is a future polish, not a v1 requirement.
+
+## Future Extensions
+
+The largest planned follow-up is **adding NVIDIA Parakeet** as a second transcription engine. Parakeet is CC-BY-4.0 (redistribution is fine), the int8-quantized v3 model is around 670 MB unpacked, and it runs CPU-only via ONNX Runtime — meaningfully faster than Whisper Large v3 Turbo on the same machine, with accuracy that's good enough for everyday use. The speed-vs-accuracy tradeoff makes it a strong candidate to eventually become ThoughtCast's default engine, possibly with its model bundled directly into the installer rather than downloaded post-install. That decision is for the Phase 2 PRD.
+
+**Revisiting FFmpeg bundling later** is also on the table — but only if the macOS arm64 LGPL ecosystem matures (or if I'm willing to spend the ~15-20 minutes of CI build time and the maintenance overhead). Until then, the documented user-install path is the deliberate choice, not a known-bad workaround.
+
+Two smaller follow-ups become natural once v1 ships: a "manage downloaded models" view (see sizes, free up disk space), and a Hugging Face mirror if their CDN ever rate-limits us. Neither is needed to call v1 done.
+
+## Architecture Notes
+
+- **Tauri's `bundle.resources`** is the mechanism for shipping `whisper-cli` (and, later, ONNX Runtime for Parakeet) alongside the app. Per-OS contents are selected by the existing per-OS release jobs — Windows artifact ships the Windows `whisper-cli.exe`, macOS artifact ships the arm64 `whisper-cli`. Whisper.cpp is MIT-licensed, so no licensing complications.
+- **Storage split**: bundled binaries resolve via `resource_dir()` (read-only, lives with the app install). Models live in `app_data_dir()`, subdivided per engine (`models/whisper-cpp/`, future `models/parakeet/`). User recordings and transcripts stay in `~/Documents/ThoughtCast/`, where the user can find them.
+- **FFmpeg discovery**: at startup, check `config.json` override path first, then probe the system `PATH`. If found, capture and display the version (`ffmpeg -version` first line). If missing, route the user to the install-instructions screen rather than failing transcription mid-pipeline. Short recordings (no compression, no chunking) should still work without FFmpeg.
+- **Whisper models come from Hugging Face directly** via the stable, unauthenticated URL pattern `huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-<name>.bin`. Resumable via HTTP `Range` requests; SHA-256 verification on completion.
+- **Parakeet is materially more work than Whisper.cpp** — it's not "ship another CLI binary," it's "embed ONNX Runtime as a Rust dependency plus tokenizer plus inference loop." The reference implementation is Handy's `transcribe-rs` crate. Flag as a Phase 2 risk, not a stretch goal tacked onto v1.

--- a/docs/PRD-bundle-transcription-dependencies.md
+++ b/docs/PRD-bundle-transcription-dependencies.md
@@ -1,0 +1,212 @@
+# PRD: Bundle Transcription Dependencies (Whisper.cpp + FFmpeg)
+
+## Problem Statement
+
+ThoughtCast currently delegates three things to the user before the app can do anything useful:
+
+1. Compile or install **Whisper.cpp** locally and provide an absolute path to `whisper-cli` / `whisper-cli.exe`.
+2. Install **FFmpeg** locally and provide an absolute path to the `ffmpeg` binary (used by audio compression and silence-detect chunking).
+3. Download a **Whisper model** (`.bin`) and provide its absolute path.
+
+All three live in [config.json](../src-tauri/src/recording/models.rs) (`whisperPath`, `ffmpegPath`, `modelPath`) and are managed manually through the Settings → Transcription / Compression tabs ([TranscriptionSettingsSection.tsx](../src/features/settings/sections/TranscriptionSettingsSection.tsx)). The first-run experience for a new user — or for the same user moving to a new machine — is essentially "go read [SETUP_WHISPER.md](SETUP_WHISPER.md), compile a C++ project, then come back."
+
+This is fine for me on one workstation. It is unworkable as a portable release artifact, and it pushes friction onto exactly the part of the app a user can't bypass: there is no transcription without these binaries.
+
+## Goals
+
+### Primary
+1. Ship the **Whisper.cpp CLI** and **FFmpeg** binaries inside the release artifact, per target OS (Windows x64, macOS aarch64).
+2. Resolve the bundled binaries at runtime so `config.json` no longer has to point at user-installed paths.
+3. Pin and surface the **version** of each bundled binary (visible in Settings and in About, recorded in the release notes).
+4. Replace the "Whisper CLI path" picker in Settings with model management (pick / download a model), since the binary is no longer a user concern.
+5. Provide a minimal **first-run flow** that gets a new user to a working transcription without editing any files — primarily by helping them download the default model.
+
+### Secondary
+1. Structure the resources directory so a future transcription engine (NVIDIA Parakeet, etc.) can be added without redesigning the layout.
+2. Document licensing posture for the bundled binaries (especially FFmpeg) so the project's choices are intentional, not accidental.
+
+## Non-Goals
+
+- **Bundling Whisper models**: models are 75 MB – 3 GB; they stay user-downloaded into a known directory. There is also a licensing question on redistributing some model weights that we are choosing to sidestep.
+- **Adding NVIDIA Parakeet** (or any second engine): out of scope for this PRD. The directory layout should accommodate it; the implementation does not.
+- **Building Linux artifacts**: matches the current [release workflow](../.github/workflows/release-cross-platform.yml), which only produces Windows + macOS-arm64.
+- **Intel macOS**: same — current matrix is Apple Silicon only.
+- **GPU / CUDA Whisper builds**: bundle CPU-only `whisper-cli` for both OSes for now.
+- **In-app auto-update of bundled binaries**: versions are pinned and updated by cutting a new ThoughtCast release.
+
+## Background: How Tauri Bundles Resources
+
+A quick answer to one of the open questions in the source brief, because it shapes the rest of the design.
+
+**`ThoughtCast_x.y.z_x64-setup.exe` is an NSIS installer**, not a self-contained executable. It is essentially a compressed bundle of installation logic plus everything Tauri's bundler told it to include. When the user runs it, NSIS extracts files to `C:\Program Files\ThoughtCast\` (default), including `thoughtcast.exe` and any **resources** declared in [tauri.conf.json](../src-tauri/tauri.conf.json).
+
+We already use this mechanism — the audio cue WAVs ship via:
+
+```json
+"resources": [
+  "resources/sounds/start.wav",
+  "resources/sounds/stop.wav",
+  "resources/sounds/ready.wav"
+]
+```
+
+On disk after install, those files sit next to `thoughtcast.exe` (Windows) or inside `ThoughtCast.app/Contents/Resources/` (macOS). Tauri exposes them at runtime via `resource_dir()` / the `path` plugin. This is the same hook we'll use for `whisper-cli` and `ffmpeg`.
+
+Two important consequences:
+
+- **The binaries stay separate files on disk after install.** They are *not* statically linked into `thoughtcast.exe`. They are bundled in the same installer, but the OS sees them as distinct executables that ThoughtCast happens to invoke. This is exactly the posture FFmpeg's LGPL build is designed for, and what the user identified as the safe path.
+- **The installer is per-OS already.** Our [release workflow](../.github/workflows/release-cross-platform.yml) runs separate Windows and macOS jobs. We can populate the `resources/` directory differently per OS without inventing a new pipeline.
+
+## Solution Overview
+
+### Resources Layout
+
+Add a per-tool directory under `src-tauri/resources/` so each transcription engine owns its own subtree:
+
+```
+src-tauri/resources/
+├── sounds/                       # existing audio cues
+└── bin/
+    ├── ffmpeg/
+    │   ├── windows-x64/
+    │   │   ├── ffmpeg.exe
+    │   │   └── VERSION           # e.g. "7.0.2-lgpl-shared"
+    │   └── macos-arm64/
+    │       ├── ffmpeg
+    │       └── VERSION
+    └── whisper-cpp/
+        ├── windows-x64/
+        │   ├── whisper-cli.exe
+        │   └── VERSION           # e.g. "1.7.4 (commit abcdef0)"
+        └── macos-arm64/
+            ├── whisper-cli
+            └── VERSION
+```
+
+Conventions:
+- One directory per **tool** (`whisper-cpp`, `ffmpeg`, future `parakeet`).
+- One subdirectory per **target triple** (`windows-x64`, `macos-arm64`), naming aligned with Tauri's bundle target labels for grep-ability.
+- A plain-text `VERSION` file next to each binary recording (a) upstream version and (b) any build flavor (e.g. `lgpl-shared` for FFmpeg). Read at startup, exposed in Settings and About.
+
+Tauri's `bundle.resources` config will glob include this whole tree; on each OS the bundler only ships the binaries that the runtime resolver will actually look for (see below).
+
+**Models** live separately in the user data dir, organized by tool (so each engine controls its own model format):
+
+```
+~/Documents/ThoughtCast/models/
+└── whisper-cpp/
+    ├── ggml-large-v3-turbo.bin   # downloaded via the in-app flow
+    └── ...
+```
+
+### Runtime Resolution
+
+A new module (`recording::dependencies`, or similar) becomes the single source of truth for "where is `whisper-cli` / `ffmpeg` on this machine right now?":
+
+1. **Bundled** (default): resolve via Tauri's `resource_dir()` to `bin/<tool>/<target>/<binary>`.
+2. **User override** (escape hatch): if `config.json` contains a non-empty `whisperPath` / `ffmpegPath`, prefer it. This preserves my current setup on my dev machine and gives advanced users a way to swap in a GPU-enabled or self-compiled build.
+
+The Rust call sites that today read `config.whisperPath` / `config.ffmpegPath` directly ([engine.rs](../src-tauri/src/recording/transcription/engine.rs), [ffmpeg_runner.rs](../src-tauri/src/recording/compression/ffmpeg_runner.rs), the chunking modules) all change to call `dependencies::resolve(Tool::WhisperCpp)` / `dependencies::resolve(Tool::Ffmpeg)` instead. They never see config paths directly.
+
+### Settings UI Changes
+
+**Transcription tab** becomes model-focused, not binary-focused:
+
+- Drop the "Whisper CLI" path picker.
+- Replace "Model file" path picker with a **model selector** showing:
+  - The currently selected model and its size on disk.
+  - A list of recommended Whisper.cpp models (name, size, language coverage) drawn from a small static manifest in the repo.
+  - A "Download" button per model that streams the GGML file from Hugging Face into `~/Documents/ThoughtCast/models/whisper-cpp/` with a progress indicator.
+  - A "Use existing file" affordance (file picker) for users who already have a `.bin` lying around.
+- Show **bundled tool versions** read-only at the bottom of the tab ("Whisper.cpp 1.7.4 · FFmpeg 7.0.2"), so the user can see what they're running without inspecting files.
+
+**Compression tab** drops the FFmpeg path picker for the same reason; an "advanced" disclosure can expose the override path if/when needed.
+
+### Where Whisper Models Come From
+
+The model selector hits Hugging Face directly. This is the same source the upstream `download-ggml-model.sh` script uses, and the URL pattern is stable and unauthenticated:
+
+```
+https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-<name>.bin
+```
+
+For example, the default model lives at `…/resolve/main/ggml-large-v3-turbo.bin`. The quantized variants (e.g. `ggml-large-v3-turbo-q5_0.bin`) follow the same pattern. No API key, no user-agent shenanigans — a plain HTTPS GET with redirect handling. The repo also publishes tinydiarize models under a different namespace (`akashmjn/tinydiarize-whisper.cpp`), which we ignore for v1.
+
+The static model manifest in the repo therefore needs only `{ name, display_name, size_bytes, hf_filename, recommended }` per entry; the URL is constructed by convention. Each manifest entry should include a SHA-256 so a completed download is verified before being marked usable — Hugging Face exposes blob SHAs in their LFS pointer files, so this is a one-time copy at manifest-bump time.
+
+**Why this and not a mirror**: a comparable app, [Handy](https://github.com/cjpais/Handy), hosts its own CDN (`blob.handy.computer`) and serves a curated set of models. That gives them stable URLs and the ability to repackage. The downside is paying for bandwidth on multi-GB files. We have no reason to take that on for v1 — the HF URLs have been stable for years, and if HF ever rate-limits us we can introduce a mirror later without changing the in-app UX.
+
+**Resumable downloads**: a partial `.bin.partial` file plus HTTP `Range` requests handles the "user closed the lid mid-download" case. Whisper-large-v3-turbo is 1.5 GB; resume is not optional. On success, rename `.partial` → `.bin` after the SHA verifies.
+
+### First-Run Onboarding
+
+When the app starts and `dependencies::resolve(Tool::WhisperCpp)` succeeds **but** no Whisper model is present (no file in the models dir, no `modelPath` override), open a one-screen modal:
+
+> **One more step: choose a transcription model**
+>
+> ThoughtCast transcribes audio locally using Whisper. We didn't bundle a model because they're large (75 MB – 1.5 GB depending on accuracy).
+>
+> [ Download Large v3 Turbo · 1.5 GB · recommended ]
+> [ Download Base · 142 MB · faster, less accurate ]
+> [ I already have one — pick a file ]
+
+This is the *only* mandatory onboarding step. Everything else (audio device, shortcut, compression) keeps reasonable defaults and stays accessible through Settings. If the download fails mid-stream, leave the partial file in a `.partial` filename so a retry doesn't redownload the whole thing.
+
+### Versioning the Bundled Binaries
+
+**How versions get into the bundle**: the CI workflow pulls pinned binary releases at build time, not at runtime. Concretely, the workflow gains a "fetch dependencies" step before `npm run tauri:build`:
+
+- **FFmpeg (Windows x64)**: gyan.dev's `ffmpeg-release-essentials.zip` is the boring, predictable LGPL build. Pin the version tag and extract `ffmpeg.exe`.
+- **FFmpeg (macOS arm64)**: pin against [martin-riedl.de](https://ffmpeg.martin-riedl.de/) (signed + notarized arm64 binaries) or [ColorsWind/FFmpeg-macOS](https://github.com/ColorsWind/FFmpeg-macOS) (explicit LGPLv2 universal builds). `evermeet.cx` doesn't ship Apple Silicon at all, so it's out. See open question below for which of the two we pick.
+- **Whisper.cpp**: download a pinned release tag's prebuilt CLI from the upstream GitHub release for each OS, drop the binary in place, write `VERSION`.
+
+Pinned versions and source URLs live in a single manifest in the repo (`scripts/dependencies.json` or similar) so a bump is a one-file change. The same manifest is what the runtime VERSION-display reads — there's one canonical declaration.
+
+This keeps the repo small (no committed binaries) while still being deterministic: identical commit → identical bundled versions.
+
+## Licensing Posture
+
+The user explicitly flagged this. Stating the choice so it's deliberate, not implicit:
+
+- **FFmpeg**: ship the **LGPL** build, not the GPL build. The LGPL build excludes non-free encoders (x264, x265, libfdk-aac, etc.) — we don't need any of those for our actual usage (we read WAV input, write AAC via the native `aac` encoder, and run silence detection). The LGPL build is redistributable as a separate binary alongside our app without infecting our license, which is what we want. We invoke it as a subprocess — never statically link.
+- **Whisper.cpp**: MIT-licensed; redistribution is unrestricted. No additional posture needed.
+- **Whisper model weights**: the GGML models on Hugging Face are released under MIT by ggerganov, but the underlying Whisper weights are MIT-licensed from OpenAI. Redistribution is permitted; we still choose not to bundle them, for size reasons.
+- **Documentation**: add a `THIRD_PARTY_LICENSES.md` (or extend an existing one) listing FFmpeg + Whisper.cpp versions and license texts. Tauri can also ship this file as a resource for an in-app "Licenses" view, but the doc itself is the source of truth.
+
+## Implementation Plan
+
+### Phase 1 — Build & Bundle
+1. Add `scripts/fetch-dependencies.{ps1,sh}` (or a Node script) that, given a target, downloads the pinned FFmpeg + Whisper.cpp binaries into `src-tauri/resources/bin/<tool>/<target>/` and writes `VERSION`.
+2. Wire that script into [.github/workflows/release-cross-platform.yml](../.github/workflows/release-cross-platform.yml) as a step before `npm run tauri:build`, parameterized by the runner's target triple.
+3. Add the new paths to `bundle.resources` in [tauri.conf.json](../src-tauri/tauri.conf.json).
+4. Add `src-tauri/resources/bin/` to `.gitignore` so we never accidentally commit binaries; the script is the canonical source.
+
+### Phase 2 — Runtime Resolution
+5. Introduce `recording::dependencies` with a `Tool` enum and a `resolve(tool) -> PathBuf` function that prefers user override, falls back to bundled, returns a typed error otherwise.
+6. Migrate call sites in `recording::transcription` and `recording::compression` (and chunking) to use the resolver. No more reading `whisperPath` / `ffmpegPath` directly outside of `dependencies` and the override-handling layer.
+7. Expose a Tauri command `get_bundled_tool_versions` reading the `VERSION` files, used by Settings.
+
+### Phase 3 — Settings + Model Flow
+8. Replace the Whisper CLI path picker in [TranscriptionSettingsSection.tsx](../src/features/settings/sections/TranscriptionSettingsSection.tsx) with a model list + download flow backed by new Tauri commands (`list_models`, `download_model`, `select_model`).
+9. Add a small static model manifest (name, size, download URL, recommended flag).
+10. Drop / hide the FFmpeg path picker in the Compression tab; add an "Advanced override" disclosure for users who need it.
+11. Show bundled tool versions at the bottom of the Transcription tab.
+
+### Phase 4 — First-Run + Polish
+12. Detect "no usable model" at startup and open the onboarding modal.
+13. Write `THIRD_PARTY_LICENSES.md` and link it from the README + the app's About screen.
+14. Update [CLAUDE.md](../CLAUDE.md) "Configuration" section: remove the manual `config.json` requirement; document the model download UI as the new setup path.
+
+## Open Questions
+
+1. **FFmpeg macOS source — martin-riedl.de vs ColorsWind**: both are viable LGPL builds for arm64. martin-riedl.de's appeal is that the binaries are already signed and notarized, which sidesteps some Gatekeeper friction even though we don't sign ThoughtCast itself. ColorsWind's appeal is an explicit LGPLv2 declaration on a GitHub release page, which makes the redistribution posture cleaner to document. Pick one for v1 — leaning martin-riedl.de for the notarization, with ColorsWind as a documented fallback if the martin-riedl release cadence ever drifts.
+
+(Override migration and macOS code signing are intentionally out of scope: I'm the only current user, my dev `config.json` will continue to work via the override path, and signing is deferred until there's an audience that warrants the $99/yr Apple Developer fee.)
+
+## Success Criteria
+
+1. A fresh user can download `ThoughtCast_x.y.z_x64-setup.exe` (or the `.dmg`), install, launch, click through one model-download prompt, and have a working recording → transcription → clipboard flow. No editing of `config.json`. No installing Whisper.cpp. No installing FFmpeg.
+2. Settings → Transcription shows the bundled Whisper.cpp and FFmpeg versions, and the user's currently selected model.
+3. The release artifacts contain exactly one set of binaries each (Windows artifact has no macOS binaries and vice versa), and the version files in the bundle match the version strings shown in the app.
+4. My existing dev machine, where `config.json` already points to a local Whisper.cpp build, continues to work unchanged using those paths as overrides.
+5. `THIRD_PARTY_LICENSES.md` is present and accurate at release time.


### PR DESCRIPTION
## Summary
- macOS release build broke when GitHub rolled the `macos-latest` image and the workflow restored yesterday's `~/.cargo/bin/` over the runner's fresh rustup install, leaving `cargo` on PATH pointing at the `rustup-init` bootstrapper (hence `unexpected argument 'metadata'` from `cargo metadata`).
- Removed `~/.cargo/bin/` from the cached paths in both `build-windows` and `build-macos` jobs -- toolchain binaries belong to the rustup install step, not the build cache (`Swatinem/rust-cache@v2` excludes this path for the same reason). Kept registry, git-db, and target caches, which are what actually save time.
- Bumped the cache key prefix from `${{ runner.os }}-cargo-` to `${{ runner.os }}-cargo-v2-` (key and `restore-keys`) so the poisoned macOS entry from yesterday's run is not restored on the next attempt. Windows passed only by coincidence; this is preventative on that side.
