### PR TITLE
BUG: Stop paused recordings from disappearing on stale transcription events

### DIFF
--- a/src/app/useRecordingWorkflow.test.ts
+++ b/src/app/useRecordingWorkflow.test.ts
@@ -200,6 +200,9 @@ describe('useRecordingWorkflow', () => {
   const mockRecordingService = {
     startRecording: vi.fn(),
     stopRecording: vi.fn(),
+    pauseRecording: vi.fn(),
+    resumeRecording: vi.fn(),
+    cancelRecording: vi.fn(),
     getRecordingDuration: vi.fn(),
   };
 
@@ -250,6 +253,9 @@ describe('useRecordingWorkflow', () => {
     mockSessionService.getSessions.mockResolvedValue({ sessions: mockSessions });
     mockRecordingService.startRecording.mockClear();
     mockRecordingService.stopRecording.mockClear();
+    mockRecordingService.pauseRecording.mockClear();
+    mockRecordingService.resumeRecording.mockClear();
+    mockRecordingService.cancelRecording.mockClear();
     mockRecordingService.getRecordingDuration.mockClear();
   });
 
@@ -475,5 +481,158 @@ describe('useRecordingWorkflow', () => {
     });
 
     expect(result.current.sessions).toEqual(newSessions);
+  });
+
+  // Regression tests for the "paused recording disappears" bug: a background
+  // transcription event firing for an *earlier* session must not yank the
+  // user out of their in-flight recording/paused state.
+  describe('stale transcription events during a new recording', () => {
+    const staleCompletedSession: Session = {
+      id: 'older-session',
+      timestamp: '2024-01-01T00:00:00Z',
+      duration: 10,
+      audio_path: '/path/to/older.wav',
+      transcript_path: '/path/to/older.txt',
+      preview: 'Older transcript',
+      clipboard_copied: true,
+    };
+
+    it('does not reset a paused recording when a stale completion arrives', async () => {
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      // Flush so the event listeners are wired up before we emit.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await result.current.handleStartRecording();
+      });
+      await act(async () => {
+        await result.current.handlePauseRecording();
+      });
+
+      expect(result.current.recordingStatus).toBe('paused');
+      const statusWhilePaused = result.current.status;
+
+      // Simulate a *prior* session's transcription completing in the
+      // background while the user is paused.
+      await act(async () => {
+        emitMockEvent('transcription-complete', { session: staleCompletedSession });
+        await Promise.resolve();
+      });
+
+      expect(result.current.recordingStatus).toBe('paused');
+      expect(result.current.isProcessing).toBe(false);
+      expect(result.current.status).toBe(statusWhilePaused);
+    });
+
+    it('does not reset an active recording when a stale completion arrives', async () => {
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await result.current.handleStartRecording();
+      });
+
+      expect(result.current.recordingStatus).toBe('recording');
+
+      await act(async () => {
+        emitMockEvent('transcription-complete', { session: staleCompletedSession });
+        await Promise.resolve();
+      });
+
+      expect(result.current.recordingStatus).toBe('recording');
+      expect(result.current.isProcessing).toBe(false);
+    });
+
+    it('does not reset a paused recording when a stale transcription error arrives', async () => {
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await result.current.handleStartRecording();
+      });
+      await act(async () => {
+        await result.current.handlePauseRecording();
+      });
+
+      const statusWhilePaused = result.current.status;
+
+      await act(async () => {
+        emitMockEvent('transcription-error', {
+          session_id: staleCompletedSession.id,
+          error: 'whisper failed',
+        });
+        await Promise.resolve();
+      });
+
+      expect(result.current.recordingStatus).toBe('paused');
+      expect(result.current.isProcessing).toBe(false);
+      expect(result.current.status).toBe(statusWhilePaused);
+    });
+
+    it('still refreshes the session list when a stale completion arrives', async () => {
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+
+      const refreshedSessions = [...mockSessions, staleCompletedSession];
+      mockSessionService.getSessions
+        .mockResolvedValueOnce({ sessions: mockSessions })
+        .mockResolvedValue({ sessions: refreshedSessions });
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await result.current.handleStartRecording();
+      });
+      await act(async () => {
+        await result.current.handlePauseRecording();
+      });
+
+      await act(async () => {
+        emitMockEvent('transcription-complete', { session: staleCompletedSession });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(refreshedSessions);
+      });
+      expect(result.current.recordingStatus).toBe('paused');
+    });
   });
 });

--- a/src/app/useRecordingWorkflow.ts
+++ b/src/app/useRecordingWorkflow.ts
@@ -49,6 +49,15 @@ export function autoSelectFirstSession(
 
 /**
  * Handle transcription completion event
+ *
+ * Background transcriptions (a prior recording or a user-triggered retranscribe)
+ * can finish while the user is already in the middle of a *new* recording —
+ * including paused. Without `getRecordingStatus`, this handler would
+ * unconditionally flip `recordingStatus` to `'idle'` and wipe the in-progress
+ * recording out of the UI even though the backend is still capturing it. We
+ * gate the workflow-state mutations on actually being in `'processing'`; if
+ * we're not, the event corresponds to background work and we only refresh
+ * the session list (so the completed transcript appears in the sidebar).
  */
 export function handleTranscriptionComplete(
   session: Session,
@@ -58,9 +67,22 @@ export function handleTranscriptionComplete(
     setIsProcessing: (processing: boolean) => void;
     loadSessions: () => Promise<void>;
     playReadyCue: () => void;
+    getRecordingStatus: () => RecordingStatus;
   }
 ): void {
   logger.info('Transcription completed:', session.id);
+
+  // Always refresh the session list so the completed transcript shows up,
+  // even if we shouldn't touch the recording state machine.
+  callbacks.loadSessions();
+
+  const currentStatus = callbacks.getRecordingStatus();
+  if (currentStatus !== 'processing') {
+    // A stale completion arrived while the user has already moved on (idle,
+    // recording, or paused). Suppress the workflow reset and the audio cue —
+    // playing it through speakers would bleed into the active mic capture.
+    return;
+  }
 
   // Determine and set appropriate status
   const resultStatus = determineRecordingStatus(session);
@@ -69,9 +91,6 @@ export function handleTranscriptionComplete(
   // Update recording status to idle
   callbacks.setRecordingStatus('idle');
   callbacks.setIsProcessing(false);
-
-  // Reload sessions to show updated transcript
-  callbacks.loadSessions();
 
   // Fire-and-forget "ready" cue — advisory audio feedback that the transcript
   // is now on the clipboard. Failures here are non-fatal by design (handled
@@ -84,6 +103,10 @@ export function handleTranscriptionComplete(
 
 /**
  * Handle transcription error event
+ *
+ * Mirrors `handleTranscriptionComplete`'s gating: an error event from a
+ * background transcription must not clobber a recording the user has already
+ * started afterward. See that function's docstring for details.
  */
 export function handleTranscriptionError(
   sessionId: string,
@@ -93,16 +116,23 @@ export function handleTranscriptionError(
     setRecordingStatus: (status: RecordingStatus) => void;
     setIsProcessing: (processing: boolean) => void;
     loadSessions: () => Promise<void>;
+    getRecordingStatus: () => RecordingStatus;
   }
 ): void {
   logger.error('Transcription failed for session:', sessionId, error);
 
+  // Always refresh the session list so the error state shows up even if we
+  // don't touch the recording workflow.
+  callbacks.loadSessions();
+
+  const currentStatus = callbacks.getRecordingStatus();
+  if (currentStatus !== 'processing') {
+    return;
+  }
+
   callbacks.setStatus(`⚠️ Recording saved (transcription failed: ${error})`);
   callbacks.setRecordingStatus('idle');
   callbacks.setIsProcessing(false);
-
-  // Reload sessions to show updated state
-  callbacks.loadSessions();
 
   // Reset status after delay
   setTimeout(() => callbacks.setStatus('Ready to record'), 5000);
@@ -290,13 +320,18 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
   // Listen for transcription events
   useEffect(() => {
     const setupListeners = async () => {
-      // Create callback bundle for event handlers
+      // Create callback bundle for event handlers. `getRecordingStatus` is
+      // a thunk over the live status ref so handlers see the current state
+      // at event-fire time, not the state captured when this listener was
+      // first installed — preventing a stale background transcription event
+      // from clobbering an in-progress recording.
       const callbacks = {
         setStatus,
         setRecordingStatus,
         setIsProcessing,
         loadSessions,
         playReadyCue: cues.playReady,
+        getRecordingStatus: () => recordingStatusRef.current,
       };
 
       // Listen for successful transcription completion


### PR DESCRIPTION
The `transcription-complete` and `transcription-error` listeners in useRecordingWorkflow reset recordingStatus to 'idle' unconditionally, so a background transcription from a *prior* session (or an earlier re-transcribe) firing while the user has a new recording paused would yank the UI back to the "click to record" screen even though the Rust backend was still holding the paused capture. Both handlers now gate workflow-state mutations on `getRecordingStatus() === 'processing'` via a thunk over the existing live ref, so stale events only refresh the session list and the "ready" cue is suppressed (preventing it from bleeding into the active mic).