### PR TITLE
BUG: Make recordings durable on disk and focus-gate cancel shortcut

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,9 +10,9 @@ use audio_cues::{
 use recording::{
     estimate_transcription_time, extract_transcription_stats, new_shared_progress,
     request_cancel_batch, AppConfig, BatchCompleteEvent, BatchEventEmitter, BatchProgress,
-    BatchProgressEvent, PathKind, PathValidation, RecordingState, RecordingStatus, Session,
-    SessionIndex, SharedBatchProgress, SharedRecordingState, StorageStats,
-    TranscriptionCompleteEvent, TranscriptionErrorEvent, TranscriptionEstimate,
+    BatchProgressEvent, PathKind, PathValidation, RecordingCaptureFailedEvent, RecordingState,
+    RecordingStatus, Session, SessionIndex, SharedBatchProgress, SharedRecordingState,
+    StorageStats, TranscriptionCompleteEvent, TranscriptionErrorEvent, TranscriptionEstimate,
     TranscriptionResult,
 };
 use shortcuts::{
@@ -42,25 +42,47 @@ impl BatchEventEmitter for TauriBatchEmitter {
 }
 
 #[tauri::command]
-fn start_recording(state: State<AppState>) -> Result<(), String> {
+fn start_recording(state: State<AppState>, app: tauri::AppHandle) -> Result<(), String> {
+    log::info!("Tauri command: start_recording");
     let recording_state = Arc::clone(&state.inner().recording);
-    recording::start_recording(recording_state)
+    // Forward capture-thread failures (mid-stream stream errors, init
+    // failures) to the frontend so the user sees an explicit "Recording
+    // ended unexpectedly" message instead of a silent revert to idle. The
+    // emitter is owned by the capture thread for the lifetime of the
+    // recording — `move`d in so the AppHandle clone outlives the closure.
+    let app_for_failure = app.clone();
+    recording::start_recording(recording_state, move |event: RecordingCaptureFailedEvent| {
+        log::warn!(
+            "Emitting recording-capture-failed: reason='{}', partial={:.2}s, recovered={}",
+            event.reason,
+            event.partial_duration_seconds,
+            event.recovered_session.is_some()
+        );
+        let _ = app_for_failure.emit("recording-capture-failed", event);
+    })
 }
 
 #[tauri::command]
 fn pause_recording(state: State<AppState>) -> Result<(), String> {
+    log::info!("Tauri command: pause_recording");
     let recording_state = Arc::clone(&state.inner().recording);
     recording::pause_recording(recording_state)
 }
 
 #[tauri::command]
 fn resume_recording(state: State<AppState>) -> Result<(), String> {
+    log::info!("Tauri command: resume_recording");
     let recording_state = Arc::clone(&state.inner().recording);
     recording::resume_recording(recording_state)
 }
 
 #[tauri::command]
 fn cancel_recording(state: State<AppState>) -> Result<(), String> {
+    // Logged here AND inside recording::cancel_recording so an investigation
+    // can distinguish "the command was invoked but the inner check rejected
+    // it" from "the inner cancel path ran." Crucial for the recording-loss
+    // bug class — see docs/PRD-recording-loss-prevention.md.
+    log::warn!("Tauri command: cancel_recording invoked");
     let recording_state = Arc::clone(&state.inner().recording);
     recording::cancel_recording(recording_state)
 }
@@ -145,6 +167,17 @@ fn get_recording_duration(state: State<AppState>) -> Result<f64, String> {
 fn get_recording_status(state: State<AppState>) -> Result<RecordingStatus, String> {
     let recording_state = state.inner().recording.lock().unwrap();
     Ok(recording_state.status)
+}
+
+/// Total seconds of audio durably committed to the in-flight WAV's on-disk
+/// header. Returns `None` when no recording is active or the writer hasn't
+/// flushed yet — the UI uses this to render the "Saved through MM:SS" trust
+/// signal so the user can see at a glance that long recordings are surviving
+/// on disk, not just in RAM.
+#[tauri::command]
+fn get_recording_flushed_through_seconds(state: State<AppState>) -> Result<Option<f64>, String> {
+    let recording_state = state.inner().recording.lock().unwrap();
+    Ok(recording_state.capture.flushed_through_seconds)
 }
 
 #[tauri::command]
@@ -368,13 +401,44 @@ pub fn run() {
     .manage(app_state)
     .on_menu_event(|app, event| app_menu::handle_menu_event(app, event))
     .setup(|app| {
+      // Persistent file logging: previously logs only went to the debug-mode
+      // console, which meant production incidents (the "my recording vanished"
+      // class) left zero evidence. We now write logs to
+      // `<documents>/ThoughtCast/logs/thoughtcast.log` in BOTH dev and release
+      // so post-incident forensics is possible — the user can attach a log
+      // file when reporting a loss. Rotated at 5 MB to keep a single session's
+      // worth of context without unbounded growth.
+      let log_dir = recording::get_storage_dir()
+          .map(|d| d.join("logs"))
+          .unwrap_or_else(|_| std::path::PathBuf::from("logs"));
+      let _ = std::fs::create_dir_all(&log_dir);
+      let mut targets = vec![
+          tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Folder {
+              path: log_dir,
+              file_name: Some("thoughtcast".to_string()),
+          }),
+      ];
       if cfg!(debug_assertions) {
-        app.handle().plugin(
-          tauri_plugin_log::Builder::default()
-            .level(log::LevelFilter::Info)
-            .build(),
-        )?;
+          targets.push(tauri_plugin_log::Target::new(
+              tauri_plugin_log::TargetKind::Stdout,
+          ));
+          targets.push(tauri_plugin_log::Target::new(
+              tauri_plugin_log::TargetKind::Webview,
+          ));
       }
+      app.handle().plugin(
+        tauri_plugin_log::Builder::default()
+          .level(log::LevelFilter::Info)
+          .targets(targets)
+          .max_file_size(5 * 1024 * 1024)
+          .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepOne)
+          .build(),
+      )?;
+      log::info!(
+          "ThoughtCast starting v{} (debug={})",
+          app.package_info().version,
+          cfg!(debug_assertions)
+      );
 
       let menu = app_menu::build_app_menu(app.handle())?;
       app.set_menu(menu)?;
@@ -401,6 +465,23 @@ pub fn run() {
               }
           }
           Err(e) => log::warn!("Skipping shortcut registration — config load failed: {}", e),
+      }
+
+      // Recover any in-flight WAVs left behind by a crashed previous run
+      // BEFORE the orphan-references repair walks the session index — the
+      // recovery scan adds rows for the recovered audio, and we want those
+      // rows visible to subsequent repair passes.
+      match recording::recover_orphaned_in_flight_recordings() {
+          Ok(report) => {
+              if report.recovered_sessions > 0 || report.discarded_orphans > 0 {
+                  log::info!(
+                      "Startup in-flight recovery: recovered {} sessions, discarded {} unsalvageable orphans",
+                      report.recovered_sessions,
+                      report.discarded_orphans
+                  );
+              }
+          }
+          Err(e) => log::warn!("In-flight recovery scan skipped: {}", e),
       }
 
       // Best-effort: heal any session-index / disk drift left over by an
@@ -456,6 +537,7 @@ pub fn run() {
         get_sessions,
         get_recording_duration,
         get_recording_status,
+        get_recording_flushed_through_seconds,
         get_audio_levels,
         load_config,
         save_config,

--- a/src-tauri/src/recording/audio/capture.rs
+++ b/src-tauri/src/recording/audio/capture.rs
@@ -1,58 +1,73 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::Sample;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::{Duration, Instant};
 
-use crate::recording::state::{RecordingStatus, SharedRecordingState};
+use crate::recording::audio::capture_failure::{
+    propagate_capture_failure, CaptureFailureCallback, RecordingCaptureFailedEvent,
+};
+use crate::recording::audio::streaming_writer::StreamingWavWriter;
+use crate::recording::state::SharedRecordingState;
+use crate::recording::utils::get_storage_dir;
 
-/// Start capturing audio from the default microphone
+/// Cadence at which the capture loop drains new samples from the shared buffer
+/// into the in-flight WAV writer and checks exit conditions.
+const CAPTURE_TICK_MS: u64 = 100;
+
+/// Cadence at which the streaming writer flushes its RIFF/data chunk size
+/// headers and publishes a fresh `flushed_through_seconds` trust signal onto
+/// shared state. Choosing 2 s strikes a balance: a crash loses at most ~2 s
+/// of audio that hadn't yet been reflected in the header, while header
+/// rewrites stay infrequent enough to be a rounding error in disk I/O.
+const HEADER_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Spawn the audio capture thread.
 ///
-/// Spawns a background thread that:
-/// 1. Initializes CPAL audio input stream
-/// 2. Captures audio samples to the shared buffer when recording
-/// 3. Continues running through pause/resume cycles
-/// 4. Runs until status is set to Idle
-pub fn start_capture(state: SharedRecordingState) -> Result<(), String> {
-    let mut state_guard = state.lock().unwrap();
-
-    if state_guard.is_active() {
-        return Err("Recording is already in progress.".to_string());
-    }
-
-    // Clear previous samples
-    {
-        let mut samples = state_guard.samples.lock().unwrap();
-        samples.clear();
-    }
-    state_guard.start_time = Some(chrono::Utc::now());
-    state_guard.pause_start_time = None;
-    state_guard.total_paused_duration_ms = 0;
-    state_guard.status = RecordingStatus::Recording;
-    // Clear any rate left over from a prior capture — the audio thread will
-    // populate it from the device's `default_input_config()` once it starts.
-    state_guard.sample_rate = None;
-
-    // Clone references for the recording thread
-    let samples_clone = Arc::clone(&state_guard.samples);
+/// `lifecycle::start_recording` is responsible for prepping the shared state
+/// (clearing samples, setting `status` to Recording, generating
+/// `active_session_id`, etc.) before this is called. This function just kicks
+/// off the thread.
+///
+/// `on_failure` fires when capture dies unexpectedly (init failure or mid-
+/// stream stream error). The callback receives a `RecordingCaptureFailedEvent`
+/// containing the recovered partial recording, if any.
+pub fn start_capture<F>(state: SharedRecordingState, on_failure: F) -> Result<(), String>
+where
+    F: Fn(RecordingCaptureFailedEvent) + Send + Sync + 'static,
+{
+    let samples_clone = {
+        let g = state.lock().map_err(|e| format!("Recording state poisoned: {}", e))?;
+        Arc::clone(&g.samples)
+    };
     let state_clone = Arc::clone(&state);
+    let on_failure: CaptureFailureCallback = Arc::new(on_failure);
 
-    // Spawn a thread to handle audio recording
     thread::spawn(move || {
-        if let Err(e) = run_audio_capture_loop(samples_clone, state_clone) {
-            eprintln!("Audio capture error: {}", e);
+        if let Err(e) = run_audio_capture_loop(samples_clone, state_clone.clone(), &on_failure) {
+            // Init-time failure (device unavailable, stream build error, etc.).
+            // Route through the same partial-save / event-emit path mid-stream
+            // failures use; from here the state reset + frontend warning are
+            // identical.
+            propagate_capture_failure(&state_clone, e, &on_failure);
         }
     });
 
     Ok(())
 }
 
-/// Main audio capture loop running in background thread
+/// Main audio capture loop running in background thread.
 ///
-/// Continues running while status is Recording or Paused.
-/// Only stops when status transitions to Idle.
+/// Returns `Err` for init failures (device missing, stream build failed).
+/// Returns `Ok(())` after a clean shutdown OR after handling a mid-stream
+/// failure (which is signalled via `state.capture_error` from the cpal
+/// `err_fn` callback) — in the mid-stream case the partial-save event is
+/// fired before returning, so the caller doesn't need to do anything.
 fn run_audio_capture_loop(
     samples: Arc<Mutex<Vec<f32>>>,
     state: SharedRecordingState,
+    on_failure: &CaptureFailureCallback,
 ) -> Result<(), String> {
     // Get the default audio host
     let host = cpal::default_host();
@@ -78,7 +93,18 @@ fn run_audio_capture_loop(
     // never gets transcribed.
     let device_sample_rate = config.sample_rate().0;
     if let Ok(mut state_guard) = state.lock() {
-        state_guard.sample_rate = Some(device_sample_rate);
+        state_guard.capture.sample_rate = Some(device_sample_rate);
+    }
+
+    // Create the streaming writer that gives this recording on-disk presence
+    // from the first 100 ms onwards. The path is `audio/.in-flight/<id>.wav`;
+    // `lifecycle::stop_recording` later renames it to `audio/<id>.wav` after
+    // the writer is finalized.
+    let in_flight_path = build_in_flight_path(&state)?;
+    let mut writer = StreamingWavWriter::create(&in_flight_path, device_sample_rate)?;
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.capture.in_flight_audio_path = Some(in_flight_path.clone());
+        state_guard.capture.flushed_through_seconds = Some(0.0);
     }
 
     let samples_for_stream = Arc::clone(&samples);
@@ -102,27 +128,127 @@ fn run_audio_capture_loop(
         .play()
         .map_err(|e| format!("Failed to start recording: {}", e))?;
 
-    // Keep the stream alive while recording session is active
-    loop {
-        thread::sleep(std::time::Duration::from_millis(100));
+    // Streaming-write state local to this thread. `sample_cursor` is the
+    // index up to which we have flushed the in-memory `samples` buffer to
+    // disk; anything past it is new audio waiting to be written.
+    let mut sample_cursor: usize = 0;
+    let mut last_header_flush = Instant::now();
+    let mut mid_stream_failure: Option<String> = None;
 
-        // Check if we should stop
-        if let Ok(state_guard) = state.lock() {
+    loop {
+        thread::sleep(Duration::from_millis(CAPTURE_TICK_MS));
+
+        // Drain whatever the cpal callback has accumulated since the last
+        // tick into the in-flight WAV.
+        flush_new_samples_to_disk(&samples, &mut sample_cursor, &mut writer);
+
+        // Periodically commit a fresh header so a crash leaves a readable
+        // WAV, and publish the durably-saved duration as the UI trust signal.
+        if last_header_flush.elapsed() >= HEADER_FLUSH_INTERVAL {
+            if let Err(e) = writer.flush_headers() {
+                log::warn!("Streaming WAV header flush failed (continuing): {}", e);
+            }
+            let durable_seconds = writer.duration_seconds();
+            if let Ok(mut state_guard) = state.lock() {
+                state_guard.capture.flushed_through_seconds = Some(durable_seconds);
+            }
+            last_header_flush = Instant::now();
+        }
+
+        // Exit conditions:
+        //   1. Mid-stream failure signalled by err_fn populating
+        //      `state.capture.capture_error`. Drain it and fall through to the
+        //      partial-save path.
+        //   2. Normal shutdown: status transitioned to Processing/Idle by
+        //      stop/cancel/external action.
+        if let Ok(mut state_guard) = state.lock() {
+            if let Some(reason) = state_guard.capture.capture_error.take() {
+                mid_stream_failure = Some(reason);
+                break;
+            }
             if !state_guard.is_active() {
                 break;
             }
         }
     }
 
-    // Stream will be dropped here, stopping the recording
+    // Stop the audio stream BEFORE finalizing the writer so the cpal callback
+    // can't push more samples past the cursor while we're closing.
+    drop(stream);
+
+    // Final flush of anything captured between the last tick and stop.
+    flush_new_samples_to_disk(&samples, &mut sample_cursor, &mut writer);
+
+    let final_duration = writer.duration_seconds();
+    if let Err(e) = writer.finalize() {
+        log::warn!("Streaming WAV finalize failed (file likely still readable via header repair): {}", e);
+    }
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.capture.flushed_through_seconds = Some(final_duration);
+    }
+
+    if let Some(reason) = mid_stream_failure {
+        propagate_capture_failure(&state, reason, on_failure);
+    }
+
     Ok(())
 }
 
-/// Build a CPAL input stream for a specific sample format
+/// Snapshot newly-captured samples into the streaming writer. The cursor is
+/// advanced by the snapshot length even when the write fails — repeating
+/// failed bytes would only repeat the failure, and the in-memory `samples`
+/// buffer remains the audio of record for `get_audio_levels`.
+fn flush_new_samples_to_disk(
+    samples: &Arc<Mutex<Vec<f32>>>,
+    cursor: &mut usize,
+    writer: &mut StreamingWavWriter,
+) {
+    let new_samples: Vec<f32> = {
+        let Ok(samples_guard) = samples.lock() else {
+            return;
+        };
+        if samples_guard.len() <= *cursor {
+            return;
+        }
+        samples_guard[*cursor..].to_vec()
+    };
+    *cursor += new_samples.len();
+    if let Err(e) = writer.append_f32_samples(&new_samples) {
+        log::warn!("Streaming WAV append failed (continuing): {}", e);
+    }
+}
+
+/// Resolve the in-flight WAV path from `state.active_session_id`, creating
+/// the parent directory if needed. The path lives under `audio/.in-flight/`
+/// so completed sessions (which live in `audio/`) and recoverable ones stay
+/// visibly separated on disk.
+fn build_in_flight_path(state: &SharedRecordingState) -> Result<PathBuf, String> {
+    let id = state
+        .lock()
+        .map_err(|e| format!("Recording state poisoned: {}", e))?
+        .active_session_id
+        .clone()
+        .ok_or_else(|| {
+            "active_session_id was not set before capture started — \
+             call lifecycle::start_recording, not start_capture directly"
+                .to_string()
+        })?;
+    let storage_dir = get_storage_dir()?;
+    Ok(storage_dir
+        .join("audio")
+        .join(".in-flight")
+        .join(format!("{}.wav", id)))
+}
+
+/// Build a CPAL input stream for a specific sample format.
 ///
 /// Handles conversion from various sample formats (F32, I16, U16) to F32
 /// and stores samples in the shared buffer only when status is Recording.
 /// When paused, the callback runs but samples are not collected.
+///
+/// The CPAL error callback writes any stream error into `state.capture_error`
+/// rather than just `eprintln!`'ing — the capture loop polls that field and
+/// triggers the partial-save / event-emit path when it sees a value.
 fn build_input_stream<T>(
     device: &cpal::Device,
     config: &cpal::StreamConfig,
@@ -133,7 +259,18 @@ where
     T: cpal::Sample + cpal::SizedSample,
     f32: cpal::FromSample<T>,
 {
-    let err_fn = |err| eprintln!("An error occurred on the input stream: {}", err);
+    let state_for_err = Arc::clone(&state);
+    let err_fn = move |err: cpal::StreamError| {
+        let reason = format!("Audio stream error: {}", err);
+        // Don't overwrite a previously-recorded error — the capture loop
+        // will pick up the first one and tear down. Subsequent errors from
+        // the same dying stream are noise.
+        if let Ok(mut state_guard) = state_for_err.lock() {
+            if state_guard.capture.capture_error.is_none() {
+                state_guard.capture.capture_error = Some(reason);
+            }
+        }
+    };
 
     let stream = device
         .build_input_stream(

--- a/src-tauri/src/recording/audio/capture_failure.rs
+++ b/src-tauri/src/recording/audio/capture_failure.rs
@@ -1,0 +1,329 @@
+use crate::recording::audio::streaming_writer::repair_partial_wav_header;
+use crate::recording::audio::write_wav_file;
+use crate::recording::models::{Session, CAPTURE_FAILURE_PREVIEW};
+use crate::recording::session::storage::add_session;
+use crate::recording::state::{RecordingStatus, SharedRecordingState};
+use crate::recording::utils::get_storage_dir;
+use chrono::Utc;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Callback invoked by the capture thread when audio capture fails mid-stream
+/// (CPAL `err_fn` fires) or fails to initialize. Carries the partial-save
+/// event so the caller can forward it to the frontend.
+///
+/// The callback is invoked from the spawned audio thread, on its way to
+/// shutdown — implementations should be cheap and non-blocking (e.g. emit a
+/// Tauri event and return).
+pub type CaptureFailureCallback =
+    Arc<dyn Fn(RecordingCaptureFailedEvent) + Send + Sync + 'static>;
+
+/// Run the partial-save + event-emit + state-reset sequence after a capture
+/// failure. Shared between init failures (returned `Err` from the capture
+/// loop) and mid-stream failures (signalled via `state.capture.capture_error`).
+///
+/// After this returns, `state.status` is `Idle` so the next `start_capture`
+/// can proceed without a residual "already recording" error.
+pub fn propagate_capture_failure(
+    state: &SharedRecordingState,
+    reason: String,
+    on_failure: &CaptureFailureCallback,
+) {
+    let event = build_capture_failure_event(state, reason);
+
+    // Reset state before emitting so the workflow's reconciliation tick (if it
+    // races us) sees an authoritative `idle` instead of a half-set state.
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.status = RecordingStatus::Idle;
+        state_guard.start_time = None;
+        state_guard.pause_start_time = None;
+        state_guard.total_paused_duration_ms = 0;
+        let _ = state_guard.capture.take_for_reset();
+        state_guard.active_session_id = None;
+    }
+
+    on_failure(event);
+}
+
+/// Event emitted to the frontend when the audio capture path fails mid-stream.
+///
+/// `recovered_session` is `Some` when we managed to flush whatever was buffered
+/// to disk and add it to the session index — the user can then open it and
+/// retranscribe. `recovered_session` is `None` if the failure happened before
+/// any samples were captured (or if the partial save itself failed); the UI
+/// should still surface the warning so the user knows the recording is gone.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RecordingCaptureFailedEvent {
+    pub reason: String,
+    pub partial_duration_seconds: f64,
+    pub recovered_session: Option<Session>,
+}
+
+/// Build a `RecordingCaptureFailedEvent` from a failed capture session: best-
+/// effort save whatever is in the samples buffer and register it as a session
+/// so the user can retranscribe.
+///
+/// "Best-effort" is the operative word — any failure inside this function
+/// (storage dir unavailable, disk full, sessions index corrupt) downgrades to
+/// `recovered_session: None` rather than escalating. The capture thread is
+/// already in an error path; bubbling another failure would only hide the
+/// original `reason` from the user.
+pub fn build_capture_failure_event(
+    state: &SharedRecordingState,
+    reason: String,
+) -> RecordingCaptureFailedEvent {
+    let snapshot = snapshot_recording_for_failure(state);
+
+    // Prefer promoting the streaming writer's in-flight WAV over re-writing
+    // the samples buffer. The in-flight WAV has been periodically header-
+    // flushed, so even a crash at the worst possible moment leaves at most
+    // a couple of seconds of audio loss — and we don't pay for a duplicate
+    // 16-bit encoding pass on hundreds of MB of samples.
+    let recovered_session = match promote_in_flight_to_session(state, &snapshot) {
+        Ok(session) => Some(session),
+        Err(promote_err) => {
+            log::warn!(
+                "Could not recover from in-flight WAV (reason='{}'): {}; falling back to in-memory save",
+                reason,
+                promote_err
+            );
+            match attempt_partial_save(state, &snapshot) {
+                Ok(session) => Some(session),
+                Err(save_err) => {
+                    log::warn!(
+                        "Capture failure partial save failed (reason='{}', save_error='{}')",
+                        reason,
+                        save_err
+                    );
+                    None
+                }
+            }
+        }
+    };
+
+    RecordingCaptureFailedEvent {
+        reason,
+        partial_duration_seconds: snapshot.duration_seconds,
+        recovered_session,
+    }
+}
+
+/// Promote the active streaming WAV to a permanent session row. Uses the
+/// in-flight path + session id from shared state; on success, the file ends
+/// up at `audio/<id>.wav` and a `Session` is added to the index.
+///
+/// Fails gracefully (and the caller falls back to the from-samples path)
+/// when there is no in-flight WAV — e.g. the capture thread died before it
+/// could create the writer.
+fn promote_in_flight_to_session(
+    state: &SharedRecordingState,
+    snapshot: &CaptureSnapshot,
+) -> Result<Session, String> {
+    let (in_flight_path, id) = {
+        let g = state
+            .lock()
+            .map_err(|e| format!("Recording state poisoned: {}", e))?;
+        let path = g
+            .capture
+            .in_flight_audio_path
+            .clone()
+            .ok_or_else(|| "No in-flight audio path".to_string())?;
+        let id = g
+            .active_session_id
+            .clone()
+            .ok_or_else(|| "No active session id".to_string())?;
+        (path, id)
+    };
+
+    if !in_flight_path.exists() {
+        return Err(format!(
+            "In-flight WAV expected at {} but missing",
+            in_flight_path.display()
+        ));
+    }
+
+    // The capture thread already calls `finalize` before invoking the
+    // failure path, but a header repair is cheap insurance against any
+    // crash that happened between flush ticks and never made it through
+    // `finalize`.
+    repair_partial_wav_header(&in_flight_path)?;
+
+    let permanent = promote_streaming_wav_to_permanent(&in_flight_path, &id)?;
+
+    // Use whatever duration the WAV file itself reports. Snapshot duration
+    // is computed from wall-clock and may diverge from the audio actually
+    // captured.
+    let duration = crate::recording::audio::read_wav_duration_seconds(&permanent)
+        .unwrap_or(snapshot.duration_seconds);
+
+    let session = Session::new_unrecovered(
+        id.clone(),
+        Utc::now().to_rfc3339(),
+        format!("audio/{}.wav", id),
+        duration,
+        CAPTURE_FAILURE_PREVIEW.to_string(),
+    );
+
+    add_session(session.clone())?;
+    Ok(session)
+}
+
+/// Move an in-flight WAV to its permanent `audio/<id>.wav` location.
+///
+/// Public so the normal stop path (in `session/lifecycle.rs`) and startup
+/// recovery (in `recording/recovery.rs`) reuse the same promotion logic.
+pub fn promote_streaming_wav_to_permanent(
+    in_flight_path: &Path,
+    session_id: &str,
+) -> Result<PathBuf, String> {
+    let storage_dir = get_storage_dir()?;
+    let permanent = storage_dir
+        .join("audio")
+        .join(format!("{}.wav", session_id));
+    if let Some(parent) = permanent.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create audio dir {}: {}", parent.display(), e))?;
+    }
+    std::fs::rename(in_flight_path, &permanent).map_err(|e| {
+        format!(
+            "Failed to promote in-flight WAV {} → {}: {}",
+            in_flight_path.display(),
+            permanent.display(),
+            e
+        )
+    })?;
+    Ok(permanent)
+}
+
+struct CaptureSnapshot {
+    /// Frames captured before the failure, in f32 mono.
+    samples: Vec<f32>,
+    /// Sample rate the device was running at, if the audio thread had time to
+    /// publish it before failing. Falls back to 44.1 kHz so any partial save
+    /// is at least playable (just slightly mis-timed).
+    sample_rate: u32,
+    /// Recording duration (excluding paused time) at the moment of failure.
+    /// Drives the user-facing "we saved X:XX" message and the persisted
+    /// `session.duration`.
+    duration_seconds: f64,
+}
+
+/// Take a consistent snapshot of the recording state for failure handling.
+///
+/// We pull `samples`, `sample_rate`, and `duration` under the same lock so
+/// the trio is internally consistent — the capture callback may still be
+/// running on another thread, and we don't want the published duration to
+/// disagree with the samples count we save.
+fn snapshot_recording_for_failure(state: &SharedRecordingState) -> CaptureSnapshot {
+    let Ok(state_guard) = state.lock() else {
+        // Lock poisoning is rare and unrecoverable here — return an empty
+        // snapshot so the caller can still emit a "no audio recovered" event.
+        return CaptureSnapshot {
+            samples: Vec::new(),
+            sample_rate: 44_100,
+            duration_seconds: 0.0,
+        };
+    };
+
+    let samples = state_guard
+        .samples
+        .lock()
+        .map(|s| s.clone())
+        .unwrap_or_default();
+
+    let sample_rate = state_guard.capture.sample_rate.unwrap_or(44_100);
+    let duration_seconds = duration_at_failure(&state_guard);
+
+    CaptureSnapshot {
+        samples,
+        sample_rate,
+        duration_seconds,
+    }
+}
+
+/// Duration helper local to the failure path so we don't need to make
+/// `lifecycle::calculate_duration` public for one caller.
+fn duration_at_failure(state: &crate::recording::state::RecordingState) -> f64 {
+    let Some(start_time) = state.start_time else {
+        return 0.0;
+    };
+    let now = Utc::now();
+    let total_elapsed_ms = (now - start_time).num_milliseconds();
+
+    let mut total_paused_ms = state.total_paused_duration_ms;
+    if state.status == crate::recording::state::RecordingStatus::Paused {
+        if let Some(pause_start) = state.pause_start_time {
+            total_paused_ms += (now - pause_start).num_milliseconds();
+        }
+    }
+
+    let active_ms = total_elapsed_ms - total_paused_ms;
+    if active_ms <= 0 {
+        0.0
+    } else {
+        active_ms as f64 / 1000.0
+    }
+}
+
+/// Write the snapshot's samples to a fresh session WAV and register the
+/// session in the index. Returns the new `Session` (with a sentinel preview
+/// telling the user this was a partial save) on success.
+fn attempt_partial_save(
+    state: &SharedRecordingState,
+    snapshot: &CaptureSnapshot,
+) -> Result<Session, String> {
+    if snapshot.samples.is_empty() {
+        // Nothing to save — the failure happened before any audio was
+        // captured. The caller will emit the event with `recovered_session:
+        // None` so the UI can still surface the warning.
+        return Err("No audio captured before failure".to_string());
+    }
+
+    let storage_dir = get_storage_dir()?;
+    let id = Utc::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+    let audio_relative = format!("audio/{}.wav", id);
+    let audio_path: PathBuf = storage_dir.join(&audio_relative);
+
+    write_wav_file(&snapshot.samples, &audio_path, snapshot.sample_rate)?;
+
+    let session = Session::new_unrecovered(
+        id,
+        Utc::now().to_rfc3339(),
+        audio_relative,
+        snapshot.duration_seconds,
+        CAPTURE_FAILURE_PREVIEW.to_string(),
+    );
+
+    add_session(session.clone())?;
+
+    // Drop the in-memory samples now that they are durably on disk so a
+    // subsequent retry of `start_capture` starts with a clean buffer.
+    if let Ok(state_guard) = state.lock() {
+        if let Ok(mut samples) = state_guard.samples.lock() {
+            samples.clear();
+        }
+    }
+
+    Ok(session)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_duration_at_failure_returns_zero_without_start_time() {
+        let state = crate::recording::state::RecordingState::new();
+        assert_eq!(duration_at_failure(&state), 0.0);
+    }
+
+    #[test]
+    fn test_duration_at_failure_handles_negative_clamp() {
+        // Pathological case: start_time in the future (clock skew). Result
+        // should be clamped to 0 rather than negative.
+        let mut state = crate::recording::state::RecordingState::new();
+        state.start_time = Some(Utc::now() + chrono::Duration::seconds(5));
+        let d = duration_at_failure(&state);
+        assert!(d >= 0.0, "expected non-negative duration, got {}", d);
+    }
+}

--- a/src-tauri/src/recording/audio/mod.rs
+++ b/src-tauri/src/recording/audio/mod.rs
@@ -1,7 +1,11 @@
 pub mod capture;
+pub mod capture_failure;
 pub mod level_calculator;
+pub mod streaming_writer;
 pub mod writer;
 
 pub use capture::start_capture;
+pub use capture_failure::{promote_streaming_wav_to_permanent, RecordingCaptureFailedEvent};
 pub use level_calculator::get_audio_levels;
+pub use streaming_writer::repair_partial_wav_header;
 pub use writer::{read_wav_duration_seconds, write_wav_file};

--- a/src-tauri/src/recording/audio/streaming_writer.rs
+++ b/src-tauri/src/recording/audio/streaming_writer.rs
@@ -1,0 +1,330 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+/// Constants for a 16-bit mono PCM WAV file. We commit to this format
+/// up-front because it matches what `audio/writer.rs::write_wav_file` already
+/// produces (and what whisper.cpp consumes), and because keeping the format
+/// fixed lets us hand-roll a compact, seek-friendly header that we can flush
+/// safely from the capture thread.
+const BITS_PER_SAMPLE: u16 = 16;
+const NUM_CHANNELS: u16 = 1;
+const BYTES_PER_SAMPLE: u32 = (BITS_PER_SAMPLE as u32) / 8;
+const HEADER_SIZE_BYTES: u32 = 44;
+
+/// File-offset constants the header-flush code seeks to. Documented inline so
+/// a future reader doesn't have to re-derive them from the WAV spec.
+const RIFF_CHUNK_SIZE_OFFSET: u64 = 4;
+const DATA_CHUNK_SIZE_OFFSET: u64 = 40;
+
+/// Incremental WAV writer used to give in-progress recordings on-disk presence
+/// before the user presses Stop.
+///
+/// Why a hand-rolled writer instead of `hound::WavWriter`: hound finalizes the
+/// header only when its `finalize()` method consumes the writer, which we
+/// cannot call mid-recording. We need to keep the file open across many
+/// `append_*` calls and periodically flush the RIFF/data chunk sizes so that
+/// a crash at any point leaves a *readable* WAV behind. Writing the header
+/// ourselves makes that re-flush a few-byte seek+write.
+///
+/// Crash-safety guarantees, assuming the OS flushes our writes (which the
+/// periodic `flush_headers` call enforces):
+///   - File header always reflects a sample count ≤ the actual amount of
+///     audio on disk. A reader playing back the file may stop a fraction of
+///     a second early, but never reads past valid audio.
+///   - After a crash, the data on disk between the last header flush and the
+///     crash point is recoverable by re-deriving the header from the file's
+///     length (see `recovery::repair_partial_wav_header`).
+pub struct StreamingWavWriter {
+    file: File,
+    path: PathBuf,
+    sample_rate: u32,
+    /// Count of 16-bit samples successfully written to the data chunk. Drives
+    /// both the header size fields and the `duration_seconds` trust signal
+    /// the UI surfaces.
+    samples_written: u64,
+}
+
+impl StreamingWavWriter {
+    /// Create a new WAV file at `path` and write the 44-byte header with
+    /// placeholder size fields. The header is immediately re-flushed via
+    /// `flush_headers` so even a zero-byte recording leaves a valid file.
+    pub fn create(path: &Path, sample_rate: u32) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!("Failed to create streaming WAV parent dir {}: {}", parent.display(), e)
+            })?;
+        }
+        let file = File::create(path)
+            .map_err(|e| format!("Failed to create streaming WAV at {}: {}", path.display(), e))?;
+        let mut writer = StreamingWavWriter {
+            file,
+            path: path.to_path_buf(),
+            sample_rate,
+            samples_written: 0,
+        };
+        writer.write_initial_header()?;
+        writer.flush_headers()?;
+        Ok(writer)
+    }
+
+    /// Total duration of audio on disk so far, in seconds. The
+    /// reconciliation tick reads this to publish the "Saved through" trust
+    /// signal to the UI.
+    pub fn duration_seconds(&self) -> f64 {
+        if self.sample_rate == 0 {
+            return 0.0;
+        }
+        self.samples_written as f64 / self.sample_rate as f64
+    }
+
+    /// Append a slice of f32 samples to the file, converting to the same
+    /// 16-bit signed PCM format `audio/writer.rs::write_wav_file` produces.
+    /// The header is NOT updated here — call `flush_headers` periodically to
+    /// commit the size fields so a crash leaves a readable file.
+    pub fn append_f32_samples(&mut self, samples: &[f32]) -> Result<(), String> {
+        if samples.is_empty() {
+            return Ok(());
+        }
+
+        let mut bytes: Vec<u8> = Vec::with_capacity(samples.len() * BYTES_PER_SAMPLE as usize);
+        let amplitude = i16::MAX as f32;
+        for &sample in samples {
+            let clamped = sample.clamp(-1.0, 1.0);
+            let i16_sample = (clamped * amplitude) as i16;
+            bytes.extend_from_slice(&i16_sample.to_le_bytes());
+        }
+
+        self.file
+            .write_all(&bytes)
+            .map_err(|e| format!("Failed to append samples to streaming WAV: {}", e))?;
+        self.samples_written += samples.len() as u64;
+        Ok(())
+    }
+
+    /// Re-write the RIFF and data chunk size fields based on `samples_written`,
+    /// then flush the OS file buffer. Call this periodically (e.g. every few
+    /// seconds) so the on-disk header is approximately current. A crash
+    /// between flushes loses at most the bytes written since the last flush
+    /// — but the file is still a valid WAV because the header tells a reader
+    /// to stop at the previously-committed sample count.
+    pub fn flush_headers(&mut self) -> Result<(), String> {
+        let data_bytes = self.samples_written * BYTES_PER_SAMPLE as u64;
+        let riff_size = (HEADER_SIZE_BYTES as u64) - 8 + data_bytes;
+
+        self.file
+            .seek(SeekFrom::Start(RIFF_CHUNK_SIZE_OFFSET))
+            .map_err(|e| format!("Failed to seek to RIFF size: {}", e))?;
+        self.file
+            .write_all(&(riff_size as u32).to_le_bytes())
+            .map_err(|e| format!("Failed to write RIFF size: {}", e))?;
+
+        self.file
+            .seek(SeekFrom::Start(DATA_CHUNK_SIZE_OFFSET))
+            .map_err(|e| format!("Failed to seek to data size: {}", e))?;
+        self.file
+            .write_all(&(data_bytes as u32).to_le_bytes())
+            .map_err(|e| format!("Failed to write data size: {}", e))?;
+
+        // Seek back to the end so the next `append_f32_samples` extends the
+        // file rather than overwriting from byte 44.
+        self.file
+            .seek(SeekFrom::End(0))
+            .map_err(|e| format!("Failed to seek back to file end: {}", e))?;
+
+        self.file
+            .flush()
+            .map_err(|e| format!("Failed to flush streaming WAV: {}", e))?;
+
+        Ok(())
+    }
+
+    /// Finalize the writer: flush a final header pass and drop the file
+    /// handle. Returns the path the audio lives at so the caller can rename
+    /// it to a permanent location.
+    pub fn finalize(mut self) -> Result<PathBuf, String> {
+        self.flush_headers()?;
+        let path = self.path.clone();
+        // Explicitly drop the file so the OS releases the handle before the
+        // caller tries to rename the file (Windows requires this).
+        drop(self.file);
+        Ok(path)
+    }
+
+    fn write_initial_header(&mut self) -> Result<(), String> {
+        let byte_rate = self.sample_rate * NUM_CHANNELS as u32 * BYTES_PER_SAMPLE;
+        let block_align = NUM_CHANNELS * (BITS_PER_SAMPLE / 8);
+
+        let mut header: Vec<u8> = Vec::with_capacity(HEADER_SIZE_BYTES as usize);
+        header.extend_from_slice(b"RIFF");
+        header.extend_from_slice(&0u32.to_le_bytes()); // placeholder RIFF size
+        header.extend_from_slice(b"WAVE");
+        header.extend_from_slice(b"fmt ");
+        header.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
+        header.extend_from_slice(&1u16.to_le_bytes()); // PCM format tag
+        header.extend_from_slice(&NUM_CHANNELS.to_le_bytes());
+        header.extend_from_slice(&self.sample_rate.to_le_bytes());
+        header.extend_from_slice(&byte_rate.to_le_bytes());
+        header.extend_from_slice(&block_align.to_le_bytes());
+        header.extend_from_slice(&BITS_PER_SAMPLE.to_le_bytes());
+        header.extend_from_slice(b"data");
+        header.extend_from_slice(&0u32.to_le_bytes()); // placeholder data size
+
+        debug_assert_eq!(header.len() as u32, HEADER_SIZE_BYTES);
+
+        self.file
+            .write_all(&header)
+            .map_err(|e| format!("Failed to write initial WAV header: {}", e))?;
+        Ok(())
+    }
+}
+
+/// Repair the header of a partially-written WAV file by inferring the data
+/// length from the file size on disk. Used at startup to make orphan in-flight
+/// WAVs readable when the previous app run crashed before `finalize`.
+///
+/// Strategy: trust the data chunk follows the 44-byte canonical header that
+/// `StreamingWavWriter::create` writes; anything past that is sample data. We
+/// reconcile the RIFF and data chunk sizes against the file's actual length
+/// and re-flush. On a clean shutdown via `finalize` the header is already
+/// correct and this is a no-op.
+pub fn repair_partial_wav_header(path: &Path) -> Result<(), String> {
+    let file_len = std::fs::metadata(path)
+        .map_err(|e| format!("Failed to stat {} for header repair: {}", path.display(), e))?
+        .len();
+
+    if file_len < HEADER_SIZE_BYTES as u64 {
+        return Err(format!(
+            "WAV at {} is shorter than a 44-byte header ({} bytes); cannot repair",
+            path.display(),
+            file_len
+        ));
+    }
+
+    let data_bytes = file_len - HEADER_SIZE_BYTES as u64;
+    let riff_size = file_len - 8;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|e| format!("Failed to open {} for header repair: {}", path.display(), e))?;
+
+    file.seek(SeekFrom::Start(RIFF_CHUNK_SIZE_OFFSET))
+        .map_err(|e| format!("Failed to seek to RIFF size during repair: {}", e))?;
+    file.write_all(&(riff_size as u32).to_le_bytes())
+        .map_err(|e| format!("Failed to write RIFF size during repair: {}", e))?;
+
+    file.seek(SeekFrom::Start(DATA_CHUNK_SIZE_OFFSET))
+        .map_err(|e| format!("Failed to seek to data size during repair: {}", e))?;
+    file.write_all(&(data_bytes as u32).to_le_bytes())
+        .map_err(|e| format!("Failed to write data size during repair: {}", e))?;
+
+    file.flush()
+        .map_err(|e| format!("Failed to flush header repair on {}: {}", path.display(), e))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recording::audio::writer::read_wav_duration_seconds;
+
+    fn temp_path(name: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "thoughtcast_streaming_writer_test_{}_{}_{}.wav",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+            name,
+        ));
+        p
+    }
+
+    #[test]
+    fn empty_writer_produces_a_valid_zero_length_wav() {
+        let path = temp_path("empty");
+        let writer = StreamingWavWriter::create(&path, 48_000).expect("create");
+        writer.finalize().expect("finalize");
+
+        let duration = read_wav_duration_seconds(&path).expect("read duration");
+        assert_eq!(duration, 0.0);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn appended_samples_round_trip_through_hound() {
+        let path = temp_path("appended");
+        let mut writer = StreamingWavWriter::create(&path, 48_000).expect("create");
+        // 1 second of zero samples at 48 kHz.
+        let samples = vec![0.0f32; 48_000];
+        writer.append_f32_samples(&samples).expect("append");
+        writer.finalize().expect("finalize");
+
+        let duration = read_wav_duration_seconds(&path).expect("read duration");
+        assert!((duration - 1.0).abs() < 0.001, "expected ~1s, got {}", duration);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn flush_headers_makes_a_pre_finalize_file_readable() {
+        // Simulate "crash before finalize": create + append + flush, but
+        // never call finalize. Re-open with hound and confirm the duration
+        // matches what we wrote.
+        let path = temp_path("preflush");
+        let mut writer = StreamingWavWriter::create(&path, 48_000).expect("create");
+        writer.append_f32_samples(&vec![0.0f32; 24_000]).expect("append"); // 0.5 s
+        writer.flush_headers().expect("flush");
+        // Drop without finalize to simulate an abrupt exit.
+        drop(writer);
+
+        let duration = read_wav_duration_seconds(&path).expect("read duration");
+        assert!((duration - 0.5).abs() < 0.01, "expected ~0.5s, got {}", duration);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn repair_partial_wav_header_recovers_unflushed_tail() {
+        // Simulate a worst-case crash: data appended after the last
+        // flush_headers, so the on-disk header underestimates the data. The
+        // recovery routine should re-derive sizes from file length.
+        let path = temp_path("repair");
+        let mut writer = StreamingWavWriter::create(&path, 48_000).expect("create");
+        writer.append_f32_samples(&vec![0.0f32; 48_000]).expect("first append"); // 1.0 s
+        writer.flush_headers().expect("flush after first append");
+        writer.append_f32_samples(&vec![0.0f32; 24_000]).expect("second append"); // +0.5 s, NOT flushed
+        // Drop the writer mid-recording without flushing the new tail.
+        drop(writer);
+
+        // Pre-repair, the header reports only 1.0 s.
+        let pre = read_wav_duration_seconds(&path).expect("read pre-repair");
+        assert!((pre - 1.0).abs() < 0.01, "pre-repair expected 1.0s, got {}", pre);
+
+        repair_partial_wav_header(&path).expect("repair");
+
+        // Post-repair, the header reflects the full 1.5 s on disk.
+        let post = read_wav_duration_seconds(&path).expect("read post-repair");
+        assert!((post - 1.5).abs() < 0.01, "post-repair expected 1.5s, got {}", post);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn duration_seconds_advances_with_appends() {
+        let path = temp_path("duration");
+        let mut writer = StreamingWavWriter::create(&path, 16_000).expect("create");
+        assert_eq!(writer.duration_seconds(), 0.0);
+        writer.append_f32_samples(&vec![0.0f32; 16_000]).expect("append 1s");
+        assert!((writer.duration_seconds() - 1.0).abs() < 1e-9);
+        writer.append_f32_samples(&vec![0.0f32; 8_000]).expect("append +0.5s");
+        assert!((writer.duration_seconds() - 1.5).abs() < 1e-9);
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src-tauri/src/recording/mod.rs
+++ b/src-tauri/src/recording/mod.rs
@@ -4,6 +4,7 @@ mod chunking;
 mod compression;
 mod config;
 mod models;
+mod recovery;
 mod session;
 mod state;
 mod statistics;
@@ -43,6 +44,13 @@ pub use utils::{copy_to_clipboard, get_storage_dir};
 
 // Audio level calculation
 pub use audio::get_audio_levels;
+
+// Capture-failure event surface (consumed by the Tauri command layer to
+// forward `recording-capture-failed` events to the frontend).
+pub use audio::RecordingCaptureFailedEvent;
+
+// Startup recovery for in-flight WAVs left behind by a previous crashed run.
+pub use recovery::recover_orphaned_in_flight_recordings;
 
 // Transcription statistics and estimation
 pub use statistics::{estimate_transcription_time, extract_transcription_stats, TranscriptionEstimate};

--- a/src-tauri/src/recording/models.rs
+++ b/src-tauri/src/recording/models.rs
@@ -33,6 +33,79 @@ pub struct Session {
     pub chunking_used_fallback: Option<bool>,
 }
 
+impl Session {
+    /// Session row for a recording the user just pressed Stop on. Transcription
+    /// has not run yet — preview shows the "Processing..." sentinel the
+    /// frontend keys off to render the transcribing UI.
+    ///
+    /// All transcription / chunking telemetry starts at `None` and is filled in
+    /// by `process_transcription_async` when Whisper finishes.
+    pub fn new_for_processing(
+        id: String,
+        timestamp: String,
+        audio_path: String,
+        duration: f64,
+    ) -> Self {
+        Self {
+            id,
+            timestamp,
+            audio_path,
+            duration,
+            preview: PROCESSING_PREVIEW.to_string(),
+            transcript_path: String::new(),
+            clipboard_copied: false,
+            transcription_time_seconds: None,
+            model_path: None,
+            chunking_analysis_seconds: None,
+            chunk_count: None,
+            chunking_used_fallback: None,
+        }
+    }
+
+    /// Session row for an unrecovered / partial recording: an in-flight WAV
+    /// promoted to disk via capture failure or startup crash-recovery scan.
+    /// `preview` is the user-facing message ("audio saved, transcribe
+    /// manually" vs. "recovered from previous session" vs. similar).
+    pub fn new_unrecovered(
+        id: String,
+        timestamp: String,
+        audio_path: String,
+        duration: f64,
+        preview: String,
+    ) -> Self {
+        Self {
+            id,
+            timestamp,
+            audio_path,
+            duration,
+            preview,
+            transcript_path: String::new(),
+            clipboard_copied: false,
+            transcription_time_seconds: None,
+            model_path: None,
+            chunking_analysis_seconds: None,
+            chunk_count: None,
+            chunking_used_fallback: None,
+        }
+    }
+}
+
+/// Sentinel preview value the frontend keys off to render the in-flight
+/// transcribing view. Public so the lifecycle and retranscription paths can
+/// reuse it without re-typing the literal.
+pub const PROCESSING_PREVIEW: &str = "Processing...";
+
+/// User-facing preview for a session that ended via mid-stream capture
+/// failure. Used by both the live failure path and any future tooling that
+/// constructs such rows.
+pub const CAPTURE_FAILURE_PREVIEW: &str =
+    "⚠️ Recording ended unexpectedly — audio saved, transcribe manually";
+
+/// User-facing preview for a session recovered on startup from an orphan
+/// in-flight WAV (previous app run crashed before finalizing).
+pub const RECOVERED_ON_STARTUP_PREVIEW: &str =
+    "♻️ Recovered from previous session — open to transcribe";
+
 /// Index containing all recording sessions
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionIndex {

--- a/src-tauri/src/recording/recovery.rs
+++ b/src-tauri/src/recording/recovery.rs
@@ -1,0 +1,213 @@
+//! Startup recovery for in-flight WAVs left behind by a previous crashed run.
+//!
+//! When the app exits cleanly, the streaming writer in
+//! `audio/streaming_writer.rs` is finalized and the lifecycle code renames its
+//! in-flight WAV to its permanent `audio/<id>.wav` location. A crash or force-
+//! kill between those steps leaves the WAV in `audio/.in-flight/` with no
+//! entry in `sessions.json`. This module scans for those orphans at startup
+//! and surfaces them as recoverable sessions so the user never has to manually
+//! salvage audio from disk.
+
+use crate::recording::audio::{
+    promote_streaming_wav_to_permanent, read_wav_duration_seconds, repair_partial_wav_header,
+};
+use crate::recording::models::{Session, RECOVERED_ON_STARTUP_PREVIEW};
+use crate::recording::session::storage::{add_session, load_sessions};
+use crate::recording::utils::get_storage_dir;
+use chrono::Utc;
+use std::path::PathBuf;
+
+/// Summary of the startup recovery scan, returned for logging.
+#[derive(Debug, Default)]
+pub struct RecoveryReport {
+    /// In-flight WAVs that were promoted to permanent sessions on this scan.
+    pub recovered_sessions: usize,
+    /// In-flight files that were deleted because they couldn't be salvaged
+    /// (too small to contain a valid header, or empty). Counted separately so
+    /// the log distinguishes real recovery from cleanup.
+    pub discarded_orphans: usize,
+}
+
+/// Scan `audio/.in-flight/` for WAVs that a previous app run left behind and
+/// surface them as recoverable sessions.
+///
+/// Why this is necessary: the streaming writer in `audio/streaming_writer.rs`
+/// commits audio to disk continuously, but on a clean stop the lifecycle code
+/// renames the in-flight file to its permanent location and adds a session
+/// row. A crash (or force-kill) between sample writes and that rename leaves
+/// the WAV in `.in-flight/` with no entry in `sessions.json`. This scan
+/// fixes that: each orphan gets its header repaired, gets renamed into
+/// `audio/`, and gets a session row inserted so it appears in the sidebar
+/// like any other recording. The preview makes the recovery origin visible
+/// to the user.
+///
+/// Idempotent — running it multiple times against the same on-disk state
+/// produces the same final state (subsequent runs see an empty in-flight
+/// directory).
+pub fn recover_orphaned_in_flight_recordings() -> Result<RecoveryReport, String> {
+    let mut report = RecoveryReport::default();
+
+    let in_flight_dir = match locate_in_flight_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            // Storage dir unavailable is fatal; treat any other locate failure
+            // as "nothing to recover" and continue.
+            log::debug!("Skipping in-flight recovery scan: {}", e);
+            return Ok(report);
+        }
+    };
+
+    if !in_flight_dir.exists() {
+        return Ok(report);
+    }
+
+    let entries = std::fs::read_dir(&in_flight_dir).map_err(|e| {
+        format!(
+            "Failed to read in-flight dir {}: {}",
+            in_flight_dir.display(),
+            e
+        )
+    })?;
+
+    let existing_ids = load_sessions().map(session_ids).unwrap_or_default();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_wav_file(&path) {
+            continue;
+        }
+
+        let id = match derive_session_id_from_path(&path) {
+            Some(id) => id,
+            None => continue,
+        };
+
+        if existing_ids.contains(&id) {
+            // A previous run already added a session for this id (rare —
+            // would require a crash after `add_session` but before the
+            // rename). Promote anyway so the audio lives at the canonical
+            // path the session row points to.
+            log::info!("In-flight WAV {} matches an existing session id; promoting in place", id);
+        }
+
+        match recover_one_orphan(&path, &id) {
+            Ok(true) => report.recovered_sessions += 1,
+            Ok(false) => report.discarded_orphans += 1,
+            Err(e) => {
+                // Leave the file in place so a future scan can try again.
+                // Surfacing it as an error here would block the rest of the
+                // scan; logging keeps recovery best-effort.
+                log::warn!(
+                    "Failed to recover in-flight WAV {}: {}",
+                    path.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Try to recover a single orphan in-flight WAV. Returns `Ok(true)` if a
+/// session row was added, `Ok(false)` if the file was discarded as unsalvageable.
+fn recover_one_orphan(path: &PathBuf, session_id: &str) -> Result<bool, String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|e| format!("metadata({}): {}", path.display(), e))?;
+
+    // Anything shorter than a header has no audio worth keeping.
+    const MIN_USEFUL_BYTES: u64 = 44 + 2; // header + at least one sample
+    if metadata.len() < MIN_USEFUL_BYTES {
+        std::fs::remove_file(path)
+            .map_err(|e| format!("Failed to remove empty in-flight WAV: {}", e))?;
+        return Ok(false);
+    }
+
+    if let Err(e) = repair_partial_wav_header(path) {
+        // Last-ditch: the header is unreadable. Don't promote — but also
+        // don't leave a corrupt file blocking future recovery attempts.
+        std::fs::remove_file(path)
+            .map_err(|rm_err| format!("Header unreadable ({}) and remove failed: {}", e, rm_err))?;
+        return Ok(false);
+    }
+
+    let permanent = promote_streaming_wav_to_permanent(path, session_id)?;
+    let duration = read_wav_duration_seconds(&permanent).unwrap_or(0.0);
+
+    let session = Session::new_unrecovered(
+        session_id.to_string(),
+        derive_timestamp(session_id),
+        format!("audio/{}.wav", session_id),
+        duration,
+        RECOVERED_ON_STARTUP_PREVIEW.to_string(),
+    );
+    add_session(session)?;
+
+    Ok(true)
+}
+
+fn locate_in_flight_dir() -> Result<PathBuf, String> {
+    let storage = get_storage_dir()?;
+    Ok(storage.join("audio").join(".in-flight"))
+}
+
+fn is_wav_file(path: &PathBuf) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.eq_ignore_ascii_case("wav"))
+            .unwrap_or(false)
+}
+
+fn derive_session_id_from_path(path: &PathBuf) -> Option<String> {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+}
+
+fn session_ids(index: crate::recording::models::SessionIndex) -> std::collections::HashSet<String> {
+    index.sessions.into_iter().map(|s| s.id).collect()
+}
+
+/// Best-effort timestamp parsing for a recovered session. The id is generated
+/// from `%Y-%m-%d_%H-%M-%S` at start time, so the most reliable thing we can
+/// do is reuse that format to reconstruct an RFC3339 timestamp; on parse
+/// failure we use the current time so the session at least sorts to the top.
+fn derive_timestamp(session_id: &str) -> String {
+    match chrono::NaiveDateTime::parse_from_str(session_id, "%Y-%m-%d_%H-%M-%S") {
+        Ok(naive) => naive.and_utc().to_rfc3339(),
+        Err(_) => Utc::now().to_rfc3339(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_timestamp_parses_canonical_session_id() {
+        let ts = derive_timestamp("2026-05-17_14-22-00");
+        // Either the canonical RFC3339 form or the fallback (current time)
+        // is acceptable; we just want a non-empty result with a recognizable
+        // structure.
+        assert!(ts.contains("2026-05-17"), "expected canonical date, got {}", ts);
+    }
+
+    #[test]
+    fn derive_timestamp_falls_back_for_garbled_id() {
+        let ts = derive_timestamp("not a real id");
+        // Should not panic and should produce a non-empty RFC3339-ish string
+        // (current time fallback).
+        assert!(!ts.is_empty());
+    }
+
+    #[test]
+    fn derive_session_id_strips_extension() {
+        let path: PathBuf = "/data/.in-flight/2026-05-17_14-22-00.wav".into();
+        assert_eq!(
+            derive_session_id_from_path(&path),
+            Some("2026-05-17_14-22-00".to_string())
+        );
+    }
+}

--- a/src-tauri/src/recording/session/lifecycle.rs
+++ b/src-tauri/src/recording/session/lifecycle.rs
@@ -1,26 +1,55 @@
-use crate::recording::audio::{read_wav_duration_seconds, start_capture, write_wav_file};
-use crate::recording::compression::{run_post_transcription_compression, SessionAudioCompressedEvent};
-use crate::recording::models::{AppConfig, Session};
+use crate::recording::audio::{
+    repair_partial_wav_header, start_capture, write_wav_file, RecordingCaptureFailedEvent,
+};
+use crate::recording::models::Session;
 use crate::recording::session::storage::add_session;
 use crate::recording::state::{RecordingStatus, SharedRecordingState};
-use crate::recording::transcription::{
-    decode_to_wav, transcribe_in_chunks, transcribe_with_whisper, ChunkingTelemetry,
-};
-use crate::recording::utils::{copy_to_clipboard, get_storage_dir};
+use crate::recording::utils::get_storage_dir;
 use chrono::Utc;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::thread;
-use std::time::Instant;
 
-/// Start a new recording session
+/// Start a new recording session.
 ///
-/// Initializes audio capture and manages recording state
-pub fn start_recording(state: SharedRecordingState) -> Result<(), String> {
-    start_capture(state)
+/// Generates the session ID up-front (so the streaming WAV writer in
+/// `capture.rs` has a stable path to write to from the first sample) and preps
+/// shared state atomically before spawning the capture thread.
+///
+/// `on_capture_failure` is invoked from the capture thread if the stream dies
+/// mid-session (e.g. microphone disconnect, OS denies access, init failure) —
+/// the workflow receives a `RecordingCaptureFailedEvent` containing any audio
+/// that was captured up to the failure point so the user can still recover it.
+pub fn start_recording<F>(state: SharedRecordingState, on_capture_failure: F) -> Result<(), String>
+where
+    F: Fn(RecordingCaptureFailedEvent) + Send + Sync + 'static,
+{
+    let now = Utc::now();
+    let session_id = now.format("%Y-%m-%d_%H-%M-%S").to_string();
+
+    {
+        let mut state_guard = state.lock().unwrap();
+        if state_guard.is_active() {
+            return Err("Recording is already in progress.".to_string());
+        }
+        if let Ok(mut samples) = state_guard.samples.lock() {
+            samples.clear();
+        }
+        state_guard.start_time = Some(now);
+        state_guard.pause_start_time = None;
+        state_guard.total_paused_duration_ms = 0;
+        state_guard.status = RecordingStatus::Recording;
+        // Capture-thread-published fields reset for the new session. We
+        // discard the previous in-flight path (`take_for_reset` returns it)
+        // because the prior session was already either stopped, cancelled,
+        // or failed — those paths take ownership of their own cleanup.
+        let _ = state_guard.capture.take_for_reset();
+        state_guard.active_session_id = Some(session_id);
+    }
+
+    start_capture(state, on_capture_failure)
 }
 
-/// Pause the current recording session
+/// Pause the current recording session.
 ///
 /// Stops audio capture while preserving existing recording.
 /// Recording can be resumed to continue from this point.
@@ -37,9 +66,8 @@ pub fn pause_recording(state: SharedRecordingState) -> Result<(), String> {
     Ok(())
 }
 
-/// Resume a paused recording session
-///
-/// Continues audio capture from where it was paused.
+/// Resume a paused recording session. Continues audio capture from where it
+/// was paused.
 pub fn resume_recording(state: SharedRecordingState) -> Result<(), String> {
     let mut state_guard = state.lock().unwrap();
 
@@ -60,91 +88,192 @@ pub fn resume_recording(state: SharedRecordingState) -> Result<(), String> {
     Ok(())
 }
 
-/// Cancel the current recording session
+/// Cancel the current recording session.
 ///
-/// Discards the recording without saving. No audio file or session entry is created.
+/// Discards the recording without saving. No session entry is created.
+///
+/// **The in-flight WAV is NOT deleted** — it is moved to
+/// `audio/.cancelled/<timestamp>_<id>.wav` so the user can recover from an
+/// accidental cancel. The motivating incident: third-party paths (global
+/// keyboard shortcuts firing OS-wide while the window was unfocused, or HMR
+/// edge cases in dev mode) can call cancel without the user's intent. A pure
+/// unlink at that point is unrecoverable; moving to a quarantine directory
+/// preserves the audio for manual recovery while still keeping the startup
+/// scan from re-surfacing it as a "recovered" session.
 pub fn cancel_recording(state: SharedRecordingState) -> Result<(), String> {
-    let mut state_guard = state.lock().unwrap();
+    let in_flight_to_quarantine: Option<PathBuf>;
+    let session_id_for_log: Option<String>;
+    {
+        let mut state_guard = state.lock().unwrap();
 
-    if !state_guard.is_active() {
-        return Err("No active recording to cancel.".to_string());
+        if !state_guard.is_active() {
+            log::info!(
+                "cancel_recording invoked while not active (status={:?}); no-op",
+                state_guard.status
+            );
+            return Err("No active recording to cancel.".to_string());
+        }
+
+        session_id_for_log = state_guard.active_session_id.clone();
+        log::warn!(
+            "cancel_recording fired (session_id={:?}, status={:?}, samples={})",
+            session_id_for_log,
+            state_guard.status,
+            state_guard
+                .samples
+                .lock()
+                .map(|s| s.len())
+                .unwrap_or(usize::MAX)
+        );
+
+        // Reset to idle state
+        state_guard.status = RecordingStatus::Idle;
+        state_guard.start_time = None;
+        state_guard.pause_start_time = None;
+        state_guard.total_paused_duration_ms = 0;
+
+        // Clear samples
+        if let Ok(mut samples) = state_guard.samples.lock() {
+            samples.clear();
+        }
+
+        in_flight_to_quarantine = state_guard.capture.take_for_reset();
+        state_guard.active_session_id = None;
     }
 
-    // Reset to idle state
-    state_guard.status = RecordingStatus::Idle;
-    state_guard.start_time = None;
-    state_guard.pause_start_time = None;
-    state_guard.total_paused_duration_ms = 0;
+    // Give the capture thread the same 200 ms it gets on Stop to finalize and
+    // release the file handle before we try to move the file. Without this,
+    // the rename can race the writer on Windows.
+    thread::sleep(std::time::Duration::from_millis(200));
 
-    // Clear samples
-    {
-        let mut samples = state_guard.samples.lock().unwrap();
-        samples.clear();
+    if let Some(path) = in_flight_to_quarantine {
+        if path.exists() {
+            match quarantine_cancelled_recording(&path, session_id_for_log.as_deref()) {
+                Ok(dest) => log::info!(
+                    "Moved cancelled in-flight WAV to quarantine: {}",
+                    dest.display()
+                ),
+                Err(e) => log::warn!(
+                    "Failed to quarantine cancelled in-flight WAV at {}: {}",
+                    path.display(),
+                    e
+                ),
+            }
+        }
     }
 
     Ok(())
 }
 
-/// Stop the current recording session and save the audio
+/// Move a cancelled in-flight WAV to `audio/.cancelled/<timestamp>_<id>.wav`.
+///
+/// Filenames carry the cancel timestamp first so a directory listing is
+/// chronological. The original session id is preserved as a suffix so the
+/// user can correlate with the recording they expected.
+fn quarantine_cancelled_recording(
+    in_flight_path: &Path,
+    session_id: Option<&str>,
+) -> Result<PathBuf, String> {
+    let storage_dir = get_storage_dir()?;
+    let cancelled_dir = storage_dir.join("audio").join(".cancelled");
+    std::fs::create_dir_all(&cancelled_dir).map_err(|e| {
+        format!(
+            "Failed to create cancelled-recordings dir {}: {}",
+            cancelled_dir.display(),
+            e
+        )
+    })?;
+
+    let cancel_stamp = Utc::now().format("%Y-%m-%d_%H-%M-%S");
+    let original_id = session_id
+        .or_else(|| {
+            in_flight_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+        })
+        .unwrap_or("unknown");
+    let dest = cancelled_dir.join(format!("{}_{}.wav", cancel_stamp, original_id));
+
+    std::fs::rename(in_flight_path, &dest).map_err(|e| {
+        format!(
+            "Failed to move {} → {}: {}",
+            in_flight_path.display(),
+            dest.display(),
+            e
+        )
+    })?;
+
+    Ok(dest)
+}
+
+/// Stop the current recording session and save the audio.
 ///
 /// This is the first phase of the stop workflow:
 /// 1. Stops audio capture
-/// 2. Saves audio to WAV file
+/// 2. Promotes the streaming writer's in-flight WAV to `audio/<id>.wav`
+///    (fallback: writes the samples buffer if no in-flight WAV exists)
 /// 3. Creates initial session record (without transcription)
 /// 4. Returns session info for async transcription
 ///
-/// Transcription happens asynchronously via process_transcription_async
+/// Transcription happens asynchronously via
+/// `transcription_orchestration::orchestrate_async_transcription`.
 ///
 /// Can be called from Recording or Paused state.
 pub fn stop_recording(state: SharedRecordingState) -> Result<Session, String> {
-    let mut state_guard = state.lock().unwrap();
-
-    if !state_guard.is_active() {
-        return Err("No active recording to stop.".to_string());
-    }
-
-    // If currently paused, finalize the pause duration
-    if state_guard.status == RecordingStatus::Paused {
-        if let Some(pause_start) = state_guard.pause_start_time {
-            let pause_end = Utc::now();
-            let pause_duration = (pause_end - pause_start).num_milliseconds();
-            state_guard.total_paused_duration_ms += pause_duration;
-        }
-    }
-
-    // Calculate duration (excluding paused time)
-    let duration = calculate_duration(&state_guard);
-
-    // Mark as processing (this will stop the recording thread)
-    state_guard.status = RecordingStatus::Processing;
-
-    // Wait a bit for the recording thread to finish collecting samples
-    drop(state_guard);
-    thread::sleep(std::time::Duration::from_millis(200));
-    let state_guard = state.lock().unwrap();
-
-    // Generate timestamp-based ID
+    let id: String;
     let timestamp = Utc::now();
-    let id = timestamp.format("%Y-%m-%d_%H-%M-%S").to_string();
+    let duration: f64;
+    let in_flight_path: Option<PathBuf>;
 
-    // Save audio file (returned for Tauri command to use for async transcription)
-    let _audio_path = save_audio_file(&id, &state_guard)?;
+    {
+        let mut state_guard = state.lock().unwrap();
+
+        if !state_guard.is_active() {
+            return Err("No active recording to stop.".to_string());
+        }
+
+        // If currently paused, finalize the pause duration
+        if state_guard.status == RecordingStatus::Paused {
+            if let Some(pause_start) = state_guard.pause_start_time {
+                let pause_end = Utc::now();
+                let pause_duration = (pause_end - pause_start).num_milliseconds();
+                state_guard.total_paused_duration_ms += pause_duration;
+            }
+        }
+
+        duration = calculate_duration(&state_guard);
+
+        // Use the session id we generated at `start_recording` time so the
+        // streaming WAV's filename matches the session row. Fall back to a
+        // fresh timestamp only if we somehow lost it (defensive — should not
+        // happen on the normal flow).
+        id = state_guard
+            .active_session_id
+            .clone()
+            .unwrap_or_else(|| timestamp.format("%Y-%m-%d_%H-%M-%S").to_string());
+
+        // Mark as processing — the capture thread sees this and exits its
+        // loop, draining any pending samples + finalizing the WAV header
+        // before releasing the file handle.
+        state_guard.status = RecordingStatus::Processing;
+        in_flight_path = state_guard.capture.in_flight_audio_path.clone();
+    }
+
+    // Wait a bit for the recording thread to finish writing + finalize the
+    // streaming WAV so the rename below sees a settled file with the OS
+    // handle released.
+    thread::sleep(std::time::Duration::from_millis(200));
+
+    let audio_relative = save_recording_audio(&state, &id, in_flight_path.as_deref())?;
+
+    {
+        let mut state_guard = state.lock().unwrap();
+        let _ = state_guard.capture.take_for_reset();
+        state_guard.active_session_id = None;
+    }
 
     // Create initial session record (transcription will be added later)
-    let session = Session {
-        id: id.clone(),
-        timestamp: timestamp.to_rfc3339(),
-        audio_path: format!("audio/{}.wav", id),
-        duration,
-        preview: "Processing...".to_string(),
-        transcript_path: String::new(),
-        clipboard_copied: false,
-        transcription_time_seconds: None,
-        model_path: None,
-        chunking_analysis_seconds: None,
-        chunk_count: None,
-        chunking_used_fallback: None,
-    };
+    let session = Session::new_for_processing(id.clone(), timestamp.to_rfc3339(), audio_relative, duration);
 
     // Persist initial session to index
     add_session(session.clone())?;
@@ -152,262 +281,70 @@ pub fn stop_recording(state: SharedRecordingState) -> Result<Session, String> {
     Ok(session)
 }
 
-/// Orchestrate async transcription in background thread
+/// Resolve the final on-disk audio for a stopped recording.
 ///
-/// This function spawns a background thread that:
-/// 1. Processes transcription
-/// 2. Updates session with results
-/// 3. Updates recording state to idle
-/// 4. Emits Tauri event with results
+/// Happy path: promote the streaming writer's in-flight WAV to its permanent
+/// location with a rename — no second pass over the samples needed.
 ///
-/// This is domain orchestration logic extracted from the Tauri command layer.
+/// Fallback: if there's no in-flight WAV (capture thread failed to start the
+/// writer, or this is a code path that pre-dates the streaming writer), fall
+/// back to writing the samples buffer from RAM via the existing
+/// `write_wav_file` path. Keeps the stop flow correct even when the
+/// durability layer can't engage.
 ///
-/// # Arguments
-/// * `state` - Shared recording state for status updates
-/// * `session_id` - ID of session to transcribe
-/// * `audio_path` - Path to audio file
-/// * `event_emitter` - Callback to emit Tauri events (injected dependency)
-pub fn orchestrate_async_transcription<F>(
-    state: SharedRecordingState,
-    session_id: String,
-    audio_path: std::path::PathBuf,
-    event_emitter: F,
-) where
-    F: Fn(TranscriptionResult) + Send + Sync + 'static,
-{
-    // Mark the session as in-flight for transcription before the worker thread
-    // starts so the batch-compression worker won't race it.
-    if let Ok(mut state_guard) = state.lock() {
-        state_guard.transcribing_session_ids.insert(session_id.clone());
+/// Returns the storage-relative audio path (`audio/<id>.wav`) for the
+/// `Session` row.
+fn save_recording_audio(
+    state: &SharedRecordingState,
+    id: &str,
+    in_flight_path: Option<&Path>,
+) -> Result<String, String> {
+    let storage_dir = get_storage_dir()?;
+    let audio_relative = format!("audio/{}.wav", id);
+    let permanent_path: PathBuf = storage_dir.join(&audio_relative);
+
+    if let Some(parent) = permanent_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create audio dir {}: {}", parent.display(), e))?;
     }
 
-    thread::spawn(move || {
-        // Arc the emitter so the progress callback (which fires repeatedly
-        // during chunked transcription) can share it with the success/error
-        // call paths.
-        let emitter = Arc::new(event_emitter);
-        let progress_session_id = session_id.clone();
-        let progress_emitter = Arc::clone(&emitter);
-        let progress_fn = move |current: u32, total: u32| {
-            progress_emitter(TranscriptionResult::Progress(ChunkProgressEvent {
-                session_id: progress_session_id.clone(),
-                current,
-                total,
-            }));
-        };
-
-        let result = process_transcription_async(audio_path, session_id.clone(), &progress_fn);
-
-        // Update state to idle regardless of success/failure
-        if let Ok(mut state_guard) = state.lock() {
-            state_guard.status = RecordingStatus::Idle;
-            state_guard.transcribing_session_ids.remove(&session_id);
-        }
-
-        // Emit event via injected callback
-        match result {
-            Ok(session) => {
-                let audio_path_for_compression = session.audio_path.clone();
-                let session_id_for_compression = session.id.clone();
-                emitter(TranscriptionResult::Success(session));
-
-                // Best-effort post-transcription compression. Runs on this same
-                // background thread after the success event has already fired
-                // so the UI gets a transcript first and then a follow-up
-                // compression event if compression was enabled.
-                match run_post_transcription_compression(
-                    &session_id_for_compression,
-                    &audio_path_for_compression,
-                ) {
-                    Ok(Some(compression_event)) => {
-                        emitter(TranscriptionResult::Compressed(compression_event));
-                    }
-                    Ok(None) => {
-                        // Compression disabled — nothing to do.
-                    }
-                    Err(e) => {
-                        // Non-fatal: WAV stays put, session row remains valid.
-                        log::warn!(
-                            "Post-transcription compression failed for {}: {}",
-                            session_id_for_compression,
-                            e
-                        );
-                    }
-                }
+    if let Some(in_flight) = in_flight_path {
+        if in_flight.exists() {
+            // Repair the header before promoting so any samples written
+            // between the last periodic flush and the capture thread's
+            // finalize are still readable in the permanent file.
+            if let Err(e) = repair_partial_wav_header(in_flight) {
+                log::warn!(
+                    "Header repair failed for in-flight WAV {} (continuing): {}",
+                    in_flight.display(),
+                    e
+                );
             }
-            Err(error) => emitter(TranscriptionResult::Error {
-                session_id,
-                error,
-            }),
+            std::fs::rename(in_flight, &permanent_path).map_err(|e| {
+                format!(
+                    "Failed to promote in-flight WAV {} → {}: {}",
+                    in_flight.display(),
+                    permanent_path.display(),
+                    e
+                )
+            })?;
+            return Ok(audio_relative);
         }
-    });
-}
-
-/// Per-chunk progress for a chunked transcription. `current` is 1-indexed.
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct ChunkProgressEvent {
-    pub session_id: String,
-    pub current: u32,
-    pub total: u32,
-}
-
-/// Result of async transcription for event emission
-pub enum TranscriptionResult {
-    Success(Session),
-    Progress(ChunkProgressEvent),
-    Compressed(SessionAudioCompressedEvent),
-    Error { session_id: String, error: String },
-}
-
-/// Process transcription asynchronously and update session
-///
-/// This is the second phase of the stop workflow:
-/// 1. Transcribes audio (if configured) — routes through the chunked path
-///    when the recording is long enough and chunking is enabled
-/// 2. Copies transcript to clipboard (if successful)
-/// 3. Updates session record with transcription + chunking telemetry
-///
-/// `on_progress(current, total)` fires per chunk on the chunked path. The
-/// single-shot path does not emit progress (the UI falls back to its
-/// time-based estimate).
-///
-/// Returns updated session on success, or error message on failure
-pub fn process_transcription_async(
-    audio_path: std::path::PathBuf,
-    session_id: String,
-    on_progress: &(dyn Fn(u32, u32) + Sync),
-) -> Result<Session, String> {
-    use crate::recording::session::storage::{load_sessions, save_sessions};
-
-    let mut index = load_sessions()?;
-    let audio_duration = index
-        .sessions
-        .iter()
-        .find(|s| s.id == session_id)
-        .map(|s| s.duration)
-        .unwrap_or(0.0);
-
-    // Single config load: drives both the route decision (chunking vs
-    // single-shot) and the model-path telemetry the estimator needs.
-    let config = crate::recording::load_config().ok();
-
-    let transcription_start = Instant::now();
-    let (transcript_path, preview, clipboard_copied, chunking_telemetry) =
-        run_transcription_route(
-            &audio_path,
-            &session_id,
-            audio_duration,
-            config.as_ref(),
-            on_progress,
+        log::warn!(
+            "Expected in-flight WAV at {} but it was missing; falling back to in-memory save",
+            in_flight.display()
         );
-    let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
+    }
 
-    let model_path = config.as_ref().map(|c| c.model_path.clone());
-
-    let updated_session = {
-        let session = index
-            .sessions
-            .iter_mut()
-            .find(|s| s.id == session_id)
-            .ok_or_else(|| format!("Session not found: {}", session_id))?;
-
-        session.transcript_path = transcript_path.clone();
-        session.preview = preview;
-        session.clipboard_copied = clipboard_copied;
-
-        if !transcript_path.is_empty() && audio_duration > 0.0 {
-            session.transcription_time_seconds = Some(transcription_elapsed);
-            session.model_path = model_path;
-        }
-        if let Some(telemetry) = chunking_telemetry {
-            session.chunking_analysis_seconds = Some(telemetry.analysis_seconds);
-            session.chunk_count = Some(telemetry.chunk_count);
-            session.chunking_used_fallback = Some(telemetry.used_fallback);
-        }
-
-        session.clone()
-    };
-
-    save_sessions(&index)?;
-
-    Ok(updated_session)
+    // Fallback: write from the samples buffer. This preserves the
+    // pre-streaming behavior for whatever edge cases the capture thread
+    // didn't get to set up the writer.
+    let state_guard = state.lock().unwrap();
+    let _ = save_audio_file(id, &state_guard)?;
+    Ok(audio_relative)
 }
 
-/// Decide between the chunked and single-shot transcription paths and run
-/// the chosen one. Returns the same shape the legacy single-shot path
-/// produced, plus optional chunking telemetry to persist on the session.
-///
-/// Chunking is silently disabled when FFmpeg is missing or unconfigured —
-/// the user shouldn't get a transcription failure just because chunking
-/// can't run. The path falls back to a normal single-shot transcription
-/// in that case (PRD edge case 7).
-fn run_transcription_route(
-    audio_path: &Path,
-    session_id: &str,
-    audio_duration_sec: f64,
-    config: Option<&AppConfig>,
-    on_progress: &(dyn Fn(u32, u32) + Sync),
-) -> (String, String, bool, Option<ChunkingTelemetry>) {
-    if let Some(cfg) = config {
-        if should_use_chunking(cfg, audio_duration_sec) {
-            return run_chunked_path(audio_path, session_id, audio_duration_sec, cfg, on_progress);
-        }
-    }
-
-    let (path, preview, copied) = process_transcription(audio_path, session_id);
-    (path, preview, copied, None)
-}
-
-fn should_use_chunking(config: &AppConfig, audio_duration_sec: f64) -> bool {
-    if !config.audio_chunking.enabled {
-        return false;
-    }
-    let ffmpeg = config.ffmpeg_path.trim();
-    if ffmpeg.is_empty() {
-        return false;
-    }
-    if !Path::new(ffmpeg).exists() {
-        log::warn!("Chunking enabled but FFmpeg not found at '{}' — running single-shot transcription instead", ffmpeg);
-        return false;
-    }
-    audio_duration_sec > config.audio_chunking.min_chunk_duration_sec
-}
-
-fn run_chunked_path(
-    audio_path: &Path,
-    session_id: &str,
-    audio_duration_sec: f64,
-    config: &AppConfig,
-    on_progress: &(dyn Fn(u32, u32) + Sync),
-) -> (String, String, bool, Option<ChunkingTelemetry>) {
-    match transcribe_in_chunks(audio_path, session_id, audio_duration_sec, config, on_progress) {
-        Ok(outcome) => {
-            let preview = generate_preview(&outcome.transcript_text);
-            let clipboard_copied = if !outcome.transcript_text.is_empty() {
-                copy_to_clipboard(&outcome.transcript_text).is_ok()
-            } else {
-                false
-            };
-            (
-                outcome.transcript_path,
-                preview,
-                clipboard_copied,
-                Some(outcome.telemetry),
-            )
-        }
-        Err(e) => {
-            log::error!("Chunked transcription failed: {}", e);
-            (
-                String::new(),
-                format!("Transcription failed: {}", e),
-                false,
-                None,
-            )
-        }
-    }
-}
-
-/// Calculate recording duration from start time, excluding paused time
+/// Calculate recording duration from start time, excluding paused time.
 fn calculate_duration(state: &crate::recording::state::RecordingState) -> f64 {
     if let Some(start_time) = state.start_time {
         let end_time = Utc::now();
@@ -419,7 +356,8 @@ fn calculate_duration(state: &crate::recording::state::RecordingState) -> f64 {
     }
 }
 
-/// Save recorded audio samples to a WAV file
+/// Save recorded audio samples to a WAV file (fallback when no in-flight WAV
+/// is present — see `save_recording_audio`).
 ///
 /// Uses the device-reported sample rate the audio thread published on the
 /// state. Falls back to 44.1 kHz only if the audio thread hasn't populated it
@@ -428,403 +366,14 @@ fn calculate_duration(state: &crate::recording::state::RecordingState) -> f64 {
 fn save_audio_file(
     id: &str,
     state: &crate::recording::state::RecordingState,
-) -> Result<std::path::PathBuf, String> {
+) -> Result<PathBuf, String> {
     let storage_dir = get_storage_dir()?;
     let audio_filename = format!("{}.wav", id);
     let audio_path = storage_dir.join("audio").join(&audio_filename);
 
-    let sample_rate = state.sample_rate.unwrap_or(44_100);
+    let sample_rate = state.capture.sample_rate.unwrap_or(44_100);
     let samples = state.samples.lock().unwrap();
     write_wav_file(&samples, &audio_path, sample_rate)?;
 
     Ok(audio_path)
-}
-
-/// Process transcription and handle result
-///
-/// Returns (transcript_path, preview, clipboard_copied)
-fn process_transcription(
-    audio_path: &std::path::Path,
-    id: &str,
-) -> (String, String, bool) {
-    match transcribe_with_whisper(audio_path, id) {
-        Ok((path, text)) => {
-            // Generate preview from transcript
-            let preview = generate_preview(&text);
-
-            // Attempt automatic clipboard copy
-            let clipboard_copied = if !text.is_empty() {
-                match copy_to_clipboard(&text) {
-                    Ok(_) => {
-                        println!("Transcript copied to clipboard");
-                        true
-                    }
-                    Err(e) => {
-                        eprintln!("Failed to copy to clipboard: {}", e);
-                        false
-                    }
-                }
-            } else {
-                false
-            };
-
-            (path, preview, clipboard_copied)
-        }
-        Err(e) => {
-            // Log error but don't fail the recording
-            eprintln!("Transcription failed: {}", e);
-            (String::new(), format!("Transcription failed: {}", e), false)
-        }
-    }
-}
-
-/// Generate a preview string from transcript text
-fn generate_preview(text: &str) -> String {
-    if text.len() > 100 {
-        format!("{}...", &text[..100])
-    } else if text.is_empty() {
-        "No transcript".to_string()
-    } else {
-        text.to_string()
-    }
-}
-
-/// Mark a session as "in-flight" for re-transcription and return the updated
-/// session row.
-///
-/// This is the synchronous half of the retranscribe workflow — the caller is
-/// expected to hand the returned session to the frontend immediately and then
-/// kick off `orchestrate_async_retranscription` to actually run Whisper on a
-/// background thread. Mirrors the `stop_recording` → `orchestrate_async_transcription`
-/// pattern so the UI's existing "Processing..." view can light up without any
-/// new frontend plumbing.
-pub fn start_retranscription(session_id: &str) -> Result<Session, String> {
-    use crate::recording::session::storage::{load_sessions, save_sessions};
-
-    let storage_dir = get_storage_dir()?;
-    let mut index = load_sessions()?;
-
-    let session = index
-        .sessions
-        .iter_mut()
-        .find(|s| s.id == session_id)
-        .ok_or_else(|| format!("Session not found: {}", session_id))?;
-
-    let audio_path = storage_dir.join(&session.audio_path);
-    if !audio_path.exists() {
-        return Err(format!("Audio file not found: {}", audio_path.display()));
-    }
-
-    // The literal "Processing..." preview is what the SessionViewer keys off
-    // to render the spinner + estimated-time UI (see
-    // `determineTranscriptionState` on the frontend). Reusing the same marker
-    // means retranscribe gets the existing transcribing view for free.
-    session.preview = "Processing...".to_string();
-    let updated = session.clone();
-
-    save_sessions(&index)?;
-    Ok(updated)
-}
-
-/// Orchestrate async re-transcription in a background thread.
-///
-/// Mirrors `orchestrate_async_transcription`: spawns a worker, runs the
-/// retranscription pipeline, and emits the same `TranscriptionResult` events
-/// the initial-recording flow uses so the UI listeners already wired up in
-/// `useRecordingWorkflow` light up without any frontend-side changes.
-///
-/// Skips post-transcription compression — the session's source audio was
-/// already compressed (or never qualified), and re-compressing on every
-/// retranscribe would waste CPU and re-encode m4a → m4a.
-pub fn orchestrate_async_retranscription<F>(
-    state: SharedRecordingState,
-    session_id: String,
-    event_emitter: F,
-) where
-    F: Fn(TranscriptionResult) + Send + Sync + 'static,
-{
-    if let Ok(mut state_guard) = state.lock() {
-        state_guard.transcribing_session_ids.insert(session_id.clone());
-    }
-
-    thread::spawn(move || {
-        let emitter = Arc::new(event_emitter);
-        let progress_session_id = session_id.clone();
-        let progress_emitter = Arc::clone(&emitter);
-        let progress_fn = move |current: u32, total: u32| {
-            progress_emitter(TranscriptionResult::Progress(ChunkProgressEvent {
-                session_id: progress_session_id.clone(),
-                current,
-                total,
-            }));
-        };
-
-        let result = process_retranscription_async(session_id.clone(), &progress_fn);
-
-        if let Ok(mut state_guard) = state.lock() {
-            state_guard.transcribing_session_ids.remove(&session_id);
-        }
-
-        match result {
-            Ok(session) => emitter(TranscriptionResult::Success(session)),
-            Err(error) => emitter(TranscriptionResult::Error { session_id, error }),
-        }
-    });
-}
-
-/// Run the actual retranscription work: decode source audio if needed,
-/// transcribe, sync the session row's duration to the audio file's true
-/// playback duration, and persist the updated session.
-fn process_retranscription_async(
-    session_id: String,
-    on_progress: &(dyn Fn(u32, u32) + Sync),
-) -> Result<Session, String> {
-    use crate::recording::session::storage::{load_sessions, save_sessions};
-
-    let storage_dir = get_storage_dir()?;
-    let mut index = load_sessions()?;
-    let session = index
-        .sessions
-        .iter_mut()
-        .find(|s| s.id == session_id)
-        .ok_or_else(|| format!("Session not found: {}", session_id))?;
-
-    let audio_path = storage_dir.join(&session.audio_path);
-    if !audio_path.exists() {
-        return Err(format!("Audio file not found: {}", audio_path.display()));
-    }
-
-    let session_wall_clock_duration = session.duration;
-    let config = crate::recording::load_config().ok();
-
-    let (transcription_input, temp_wav_to_cleanup) =
-        prepare_retranscribe_input(&audio_path, &session_id, config.as_ref())?;
-
-    // Drive chunking off the audio file's actual apparent duration. For
-    // pre-fix recordings the WAV/M4A header was labelled 44.1 kHz while
-    // CPAL captured at 48 kHz — making playback ~8.8% longer than
-    // `session.duration`. Using the file's own timeline ensures the planner
-    // covers every second of audio that ffmpeg will actually slice.
-    let chunking_duration =
-        chunking_duration_for(&transcription_input, session_wall_clock_duration);
-
-    let transcription_start = Instant::now();
-    let (transcript_path, preview, clipboard_copied, chunking_telemetry) =
-        run_transcription_route(
-            &transcription_input,
-            &session_id,
-            chunking_duration,
-            config.as_ref(),
-            on_progress,
-        );
-    let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
-
-    if let Some(temp) = temp_wav_to_cleanup {
-        let _ = std::fs::remove_file(&temp);
-    }
-
-    if transcript_path.is_empty() {
-        return Err(preview);
-    }
-
-    let model_path = config.as_ref().map(|c| c.model_path.clone());
-
-    session.transcript_path = transcript_path.clone();
-    session.preview = preview;
-    session.clipboard_copied = clipboard_copied;
-
-    // Reconcile session.duration with the audio's actual playback length.
-    // Pre-fix recordings were stored with the wall-clock duration even though
-    // their WAV/M4A headers report a stretched timeline; without this update
-    // the UI keeps showing "17:21" for an 18:53 file forever.
-    if (chunking_duration - session_wall_clock_duration).abs() > 0.5 {
-        session.duration = chunking_duration;
-    }
-
-    if session_wall_clock_duration > 0.0 {
-        session.transcription_time_seconds = Some(transcription_elapsed);
-        session.model_path = model_path;
-    }
-    if let Some(telemetry) = chunking_telemetry {
-        session.chunking_analysis_seconds = Some(telemetry.analysis_seconds);
-        session.chunk_count = Some(telemetry.chunk_count);
-        session.chunking_used_fallback = Some(telemetry.used_fallback);
-    }
-
-    let updated = session.clone();
-    save_sessions(&index)?;
-    Ok(updated)
-}
-
-/// Resolve the WAV path to feed into the transcription route.
-///
-/// Returns `(input_for_whisper, optional_temp_to_clean_up)`. The second slot
-/// is `Some(path)` only when we created a temp WAV by decoding a compressed
-/// source, so the caller can remove it after transcription completes.
-///
-/// Failure here is fatal for the retranscribe — without WAV input the
-/// whisper.cpp call would fail anyway, and a meaningful FFmpeg error is far
-/// more diagnosable than the generic whisper failure that would follow.
-fn prepare_retranscribe_input(
-    audio_path: &Path,
-    session_id: &str,
-    config: Option<&AppConfig>,
-) -> Result<(PathBuf, Option<PathBuf>), String> {
-    if is_wav_path(audio_path) {
-        return Ok((audio_path.to_path_buf(), None));
-    }
-
-    let cfg = config.ok_or_else(|| {
-        "Cannot retranscribe compressed audio: app config could not be loaded \
-         (FFmpeg path is required to decode .m4a back to .wav)"
-            .to_string()
-    })?;
-
-    let temp_wav = derive_retranscribe_temp_path(audio_path, session_id);
-    decode_to_wav(&cfg.ffmpeg_path, audio_path, &temp_wav)?;
-    Ok((temp_wav.clone(), Some(temp_wav)))
-}
-
-/// True if `p` looks like a WAV file by extension. Whisper.cpp only accepts
-/// WAV, so anything else needs a decode step.
-fn is_wav_path(p: &Path) -> bool {
-    p.extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.eq_ignore_ascii_case("wav"))
-        .unwrap_or(false)
-}
-
-/// Co-locate the decoded WAV next to the compressed source so the chunk
-/// pipeline's per-chunk writes stay on the same volume (the chunked
-/// orchestrator does the same trick for its own workspace). The leading dot
-/// hides it from casual `ls`; the session id keeps concurrent retranscribes
-/// from colliding on the same path.
-fn derive_retranscribe_temp_path(audio_path: &Path, session_id: &str) -> PathBuf {
-    let parent = audio_path.parent().unwrap_or_else(|| Path::new("."));
-    parent.join(format!(".retranscribe-{}.wav", session_id))
-}
-
-/// Pick the duration to feed into the chunking planner: the WAV's own
-/// apparent duration if we can read it, otherwise the session's wall-clock
-/// duration. Reading the header should never fail for a file we just
-/// produced (passthrough WAV or freshly-decoded temp), but the fallback
-/// keeps retranscribe from breaking if it does.
-fn chunking_duration_for(wav_path: &Path, session_duration: f64) -> f64 {
-    match read_wav_duration_seconds(wav_path) {
-        Ok(d) if d > 0.0 => d,
-        Ok(_) => session_duration,
-        Err(e) => {
-            log::warn!(
-                "Could not read WAV duration for {} ({}); falling back to session.duration={}",
-                wav_path.display(),
-                e,
-                session_duration
-            );
-            session_duration
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_wav_path_accepts_lowercase_wav() {
-        assert!(is_wav_path(Path::new("/x/y/recording.wav")));
-    }
-
-    #[test]
-    fn test_is_wav_path_accepts_mixed_case_wav() {
-        assert!(is_wav_path(Path::new("/x/y/recording.WAV")));
-        assert!(is_wav_path(Path::new("/x/y/recording.Wav")));
-    }
-
-    #[test]
-    fn test_is_wav_path_rejects_m4a() {
-        assert!(!is_wav_path(Path::new("/x/y/recording.m4a")));
-    }
-
-    #[test]
-    fn test_is_wav_path_rejects_mp3_and_extensionless() {
-        assert!(!is_wav_path(Path::new("/x/y/recording.mp3")));
-        assert!(!is_wav_path(Path::new("/x/y/recording")));
-    }
-
-    #[test]
-    fn test_derive_retranscribe_temp_path_uses_session_id_and_sibling_dir() {
-        let audio = Path::new("/data/audio/2026-05-14_20-06-16.m4a");
-        let temp = derive_retranscribe_temp_path(audio, "2026-05-14_20-06-16");
-        // Compare path components rather than full string so the test is
-        // platform-agnostic (Windows uses `\` separators).
-        assert_eq!(temp.parent(), audio.parent());
-        assert_eq!(
-            temp.file_name().and_then(|s| s.to_str()),
-            Some(".retranscribe-2026-05-14_20-06-16.wav")
-        );
-    }
-
-    #[test]
-    fn test_derive_retranscribe_temp_path_falls_back_to_cwd_when_no_parent() {
-        let audio = Path::new("recording.m4a");
-        let temp = derive_retranscribe_temp_path(audio, "abc");
-        // Either ".retranscribe-abc.wav" (no parent) or "./.retranscribe-abc.wav"
-        // — both are valid. We just want to confirm we didn't panic and the
-        // session id ended up in the filename.
-        let s = temp.to_string_lossy();
-        assert!(s.contains(".retranscribe-abc.wav"), "got: {}", s);
-    }
-
-    #[test]
-    fn test_prepare_retranscribe_input_passes_wav_through_without_temp() {
-        let audio = Path::new("/data/audio/2026-05-14_20-06-16.wav");
-        let (input, temp) = prepare_retranscribe_input(audio, "2026-05-14_20-06-16", None)
-            .expect("WAV passthrough should not require config");
-        assert_eq!(input, audio);
-        assert!(temp.is_none(), "no temp file should be created for WAV input");
-    }
-
-    #[test]
-    fn test_chunking_duration_for_falls_back_to_session_when_wav_missing() {
-        let missing = Path::new("/nope/does/not/exist.wav");
-        let duration = chunking_duration_for(missing, 123.4);
-        assert_eq!(duration, 123.4);
-    }
-
-    #[test]
-    fn test_chunking_duration_for_uses_wav_duration_when_readable() {
-        use crate::recording::audio::write_wav_file;
-
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "thoughtcast_lifecycle_test_{}.wav",
-            std::process::id()
-        ));
-
-        // 1 second of silence at 48 kHz — apparent duration should be 1.0s.
-        let samples = vec![0.0f32; 48_000];
-        write_wav_file(&samples, &path, 48_000).expect("write should succeed");
-
-        // session.duration intentionally wrong (mimics pre-fix mislabelling).
-        let duration = chunking_duration_for(&path, 0.918);
-        assert!(
-            (duration - 1.0).abs() < 0.001,
-            "expected ~1.0s from WAV header, got {}",
-            duration
-        );
-
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[test]
-    fn test_prepare_retranscribe_input_requires_config_for_non_wav() {
-        let audio = Path::new("/data/audio/2026-05-14_20-06-16.m4a");
-        let err = prepare_retranscribe_input(audio, "2026-05-14_20-06-16", None)
-            .expect_err("non-WAV without config should fail");
-        assert!(
-            err.contains("FFmpeg path is required"),
-            "error should explain ffmpeg requirement, got: {}",
-            err
-        );
-    }
 }

--- a/src-tauri/src/recording/session/mod.rs
+++ b/src-tauri/src/recording/session/mod.rs
@@ -1,9 +1,11 @@
 pub mod lifecycle;
+pub mod retranscription;
 pub mod storage;
+pub mod transcription_orchestration;
 
 pub use lifecycle::{
-    cancel_recording, orchestrate_async_retranscription, orchestrate_async_transcription,
-    pause_recording, resume_recording, start_recording, start_retranscription, stop_recording,
-    TranscriptionResult,
+    cancel_recording, pause_recording, resume_recording, start_recording, stop_recording,
 };
+pub use retranscription::{orchestrate_async_retranscription, start_retranscription};
 pub use storage::{load_sessions, load_transcript};
+pub use transcription_orchestration::{orchestrate_async_transcription, TranscriptionResult};

--- a/src-tauri/src/recording/session/retranscription.rs
+++ b/src-tauri/src/recording/session/retranscription.rs
@@ -1,0 +1,348 @@
+use crate::recording::audio::read_wav_duration_seconds;
+use crate::recording::models::{AppConfig, Session, PROCESSING_PREVIEW};
+use crate::recording::session::transcription_orchestration::{
+    run_transcription_route, ChunkProgressEvent, TranscriptionResult,
+};
+use crate::recording::state::SharedRecordingState;
+use crate::recording::transcription::decode_to_wav;
+use crate::recording::utils::get_storage_dir;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+
+/// Mark a session as "in-flight" for re-transcription and return the updated
+/// session row.
+///
+/// This is the synchronous half of the retranscribe workflow — the caller is
+/// expected to hand the returned session to the frontend immediately and then
+/// kick off `orchestrate_async_retranscription` to actually run Whisper on a
+/// background thread. Mirrors the `stop_recording` → `orchestrate_async_transcription`
+/// pattern so the UI's existing "Processing..." view can light up without any
+/// new frontend plumbing.
+pub fn start_retranscription(session_id: &str) -> Result<Session, String> {
+    use crate::recording::session::storage::{load_sessions, save_sessions};
+
+    let storage_dir = get_storage_dir()?;
+    let mut index = load_sessions()?;
+
+    let session = index
+        .sessions
+        .iter_mut()
+        .find(|s| s.id == session_id)
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+    let audio_path = storage_dir.join(&session.audio_path);
+    if !audio_path.exists() {
+        return Err(format!("Audio file not found: {}", audio_path.display()));
+    }
+
+    // The literal "Processing..." preview is what the SessionViewer keys off
+    // to render the spinner + estimated-time UI (see
+    // `determineTranscriptionState` on the frontend). Reusing the same marker
+    // means retranscribe gets the existing transcribing view for free.
+    session.preview = PROCESSING_PREVIEW.to_string();
+    let updated = session.clone();
+
+    save_sessions(&index)?;
+    Ok(updated)
+}
+
+/// Orchestrate async re-transcription in a background thread.
+///
+/// Mirrors `orchestrate_async_transcription`: spawns a worker, runs the
+/// retranscription pipeline, and emits the same `TranscriptionResult` events
+/// the initial-recording flow uses so the UI listeners already wired up in
+/// `useRecordingWorkflow` light up without any frontend-side changes.
+///
+/// Skips post-transcription compression — the session's source audio was
+/// already compressed (or never qualified), and re-compressing on every
+/// retranscribe would waste CPU and re-encode m4a → m4a.
+pub fn orchestrate_async_retranscription<F>(
+    state: SharedRecordingState,
+    session_id: String,
+    event_emitter: F,
+) where
+    F: Fn(TranscriptionResult) + Send + Sync + 'static,
+{
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.transcribing_session_ids.insert(session_id.clone());
+    }
+
+    thread::spawn(move || {
+        let emitter = Arc::new(event_emitter);
+        let progress_session_id = session_id.clone();
+        let progress_emitter = Arc::clone(&emitter);
+        let progress_fn = move |current: u32, total: u32| {
+            progress_emitter(TranscriptionResult::Progress(ChunkProgressEvent {
+                session_id: progress_session_id.clone(),
+                current,
+                total,
+            }));
+        };
+
+        let result = process_retranscription_async(session_id.clone(), &progress_fn);
+
+        if let Ok(mut state_guard) = state.lock() {
+            state_guard.transcribing_session_ids.remove(&session_id);
+        }
+
+        match result {
+            Ok(session) => emitter(TranscriptionResult::Success(session)),
+            Err(error) => emitter(TranscriptionResult::Error { session_id, error }),
+        }
+    });
+}
+
+/// Run the actual retranscription work: decode source audio if needed,
+/// transcribe, sync the session row's duration to the audio file's true
+/// playback duration, and persist the updated session.
+fn process_retranscription_async(
+    session_id: String,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> Result<Session, String> {
+    use crate::recording::session::storage::{load_sessions, save_sessions};
+
+    let storage_dir = get_storage_dir()?;
+    let mut index = load_sessions()?;
+    let session = index
+        .sessions
+        .iter_mut()
+        .find(|s| s.id == session_id)
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+    let audio_path = storage_dir.join(&session.audio_path);
+    if !audio_path.exists() {
+        return Err(format!("Audio file not found: {}", audio_path.display()));
+    }
+
+    let session_wall_clock_duration = session.duration;
+    let config = crate::recording::load_config().ok();
+
+    let (transcription_input, temp_wav_to_cleanup) =
+        prepare_retranscribe_input(&audio_path, &session_id, config.as_ref())?;
+
+    // Drive chunking off the audio file's actual apparent duration. For
+    // pre-fix recordings the WAV/M4A header was labelled 44.1 kHz while
+    // CPAL captured at 48 kHz — making playback ~8.8% longer than
+    // `session.duration`. Using the file's own timeline ensures the planner
+    // covers every second of audio that ffmpeg will actually slice.
+    let chunking_duration =
+        chunking_duration_for(&transcription_input, session_wall_clock_duration);
+
+    let transcription_start = Instant::now();
+    let (transcript_path, preview, clipboard_copied, chunking_telemetry) = run_transcription_route(
+        &transcription_input,
+        &session_id,
+        chunking_duration,
+        config.as_ref(),
+        on_progress,
+    );
+    let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
+
+    if let Some(temp) = temp_wav_to_cleanup {
+        let _ = std::fs::remove_file(&temp);
+    }
+
+    if transcript_path.is_empty() {
+        return Err(preview);
+    }
+
+    let model_path = config.as_ref().map(|c| c.model_path.clone());
+
+    session.transcript_path = transcript_path.clone();
+    session.preview = preview;
+    session.clipboard_copied = clipboard_copied;
+
+    // Reconcile session.duration with the audio's actual playback length.
+    // Pre-fix recordings were stored with the wall-clock duration even though
+    // their WAV/M4A headers report a stretched timeline; without this update
+    // the UI keeps showing "17:21" for an 18:53 file forever.
+    if (chunking_duration - session_wall_clock_duration).abs() > 0.5 {
+        session.duration = chunking_duration;
+    }
+
+    if session_wall_clock_duration > 0.0 {
+        session.transcription_time_seconds = Some(transcription_elapsed);
+        session.model_path = model_path;
+    }
+    if let Some(telemetry) = chunking_telemetry {
+        session.chunking_analysis_seconds = Some(telemetry.analysis_seconds);
+        session.chunk_count = Some(telemetry.chunk_count);
+        session.chunking_used_fallback = Some(telemetry.used_fallback);
+    }
+
+    let updated = session.clone();
+    save_sessions(&index)?;
+    Ok(updated)
+}
+
+/// Resolve the WAV path to feed into the transcription route.
+///
+/// Returns `(input_for_whisper, optional_temp_to_clean_up)`. The second slot
+/// is `Some(path)` only when we created a temp WAV by decoding a compressed
+/// source, so the caller can remove it after transcription completes.
+///
+/// Failure here is fatal for the retranscribe — without WAV input the
+/// whisper.cpp call would fail anyway, and a meaningful FFmpeg error is far
+/// more diagnosable than the generic whisper failure that would follow.
+fn prepare_retranscribe_input(
+    audio_path: &Path,
+    session_id: &str,
+    config: Option<&AppConfig>,
+) -> Result<(PathBuf, Option<PathBuf>), String> {
+    if is_wav_path(audio_path) {
+        return Ok((audio_path.to_path_buf(), None));
+    }
+
+    let cfg = config.ok_or_else(|| {
+        "Cannot retranscribe compressed audio: app config could not be loaded \
+         (FFmpeg path is required to decode .m4a back to .wav)"
+            .to_string()
+    })?;
+
+    let temp_wav = derive_retranscribe_temp_path(audio_path, session_id);
+    decode_to_wav(&cfg.ffmpeg_path, audio_path, &temp_wav)?;
+    Ok((temp_wav.clone(), Some(temp_wav)))
+}
+
+/// True if `p` looks like a WAV file by extension. Whisper.cpp only accepts
+/// WAV, so anything else needs a decode step.
+fn is_wav_path(p: &Path) -> bool {
+    p.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("wav"))
+        .unwrap_or(false)
+}
+
+/// Co-locate the decoded WAV next to the compressed source so the chunk
+/// pipeline's per-chunk writes stay on the same volume (the chunked
+/// orchestrator does the same trick for its own workspace). The leading dot
+/// hides it from casual `ls`; the session id keeps concurrent retranscribes
+/// from colliding on the same path.
+fn derive_retranscribe_temp_path(audio_path: &Path, session_id: &str) -> PathBuf {
+    let parent = audio_path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(".retranscribe-{}.wav", session_id))
+}
+
+/// Pick the duration to feed into the chunking planner: the WAV's own
+/// apparent duration if we can read it, otherwise the session's wall-clock
+/// duration. Reading the header should never fail for a file we just
+/// produced (passthrough WAV or freshly-decoded temp), but the fallback
+/// keeps retranscribe from breaking if it does.
+fn chunking_duration_for(wav_path: &Path, session_duration: f64) -> f64 {
+    match read_wav_duration_seconds(wav_path) {
+        Ok(d) if d > 0.0 => d,
+        Ok(_) => session_duration,
+        Err(e) => {
+            log::warn!(
+                "Could not read WAV duration for {} ({}); falling back to session.duration={}",
+                wav_path.display(),
+                e,
+                session_duration
+            );
+            session_duration
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_wav_path_accepts_lowercase_wav() {
+        assert!(is_wav_path(Path::new("/x/y/recording.wav")));
+    }
+
+    #[test]
+    fn test_is_wav_path_accepts_mixed_case_wav() {
+        assert!(is_wav_path(Path::new("/x/y/recording.WAV")));
+        assert!(is_wav_path(Path::new("/x/y/recording.Wav")));
+    }
+
+    #[test]
+    fn test_is_wav_path_rejects_m4a() {
+        assert!(!is_wav_path(Path::new("/x/y/recording.m4a")));
+    }
+
+    #[test]
+    fn test_is_wav_path_rejects_mp3_and_extensionless() {
+        assert!(!is_wav_path(Path::new("/x/y/recording.mp3")));
+        assert!(!is_wav_path(Path::new("/x/y/recording")));
+    }
+
+    #[test]
+    fn test_derive_retranscribe_temp_path_uses_session_id_and_sibling_dir() {
+        let audio = Path::new("/data/audio/2026-05-14_20-06-16.m4a");
+        let temp = derive_retranscribe_temp_path(audio, "2026-05-14_20-06-16");
+        // Compare path components rather than full string so the test is
+        // platform-agnostic (Windows uses `\` separators).
+        assert_eq!(temp.parent(), audio.parent());
+        assert_eq!(
+            temp.file_name().and_then(|s| s.to_str()),
+            Some(".retranscribe-2026-05-14_20-06-16.wav")
+        );
+    }
+
+    #[test]
+    fn test_derive_retranscribe_temp_path_falls_back_to_cwd_when_no_parent() {
+        let audio = Path::new("recording.m4a");
+        let temp = derive_retranscribe_temp_path(audio, "abc");
+        let s = temp.to_string_lossy();
+        assert!(s.contains(".retranscribe-abc.wav"), "got: {}", s);
+    }
+
+    #[test]
+    fn test_prepare_retranscribe_input_passes_wav_through_without_temp() {
+        let audio = Path::new("/data/audio/2026-05-14_20-06-16.wav");
+        let (input, temp) = prepare_retranscribe_input(audio, "2026-05-14_20-06-16", None)
+            .expect("WAV passthrough should not require config");
+        assert_eq!(input, audio);
+        assert!(temp.is_none(), "no temp file should be created for WAV input");
+    }
+
+    #[test]
+    fn test_chunking_duration_for_falls_back_to_session_when_wav_missing() {
+        let missing = Path::new("/nope/does/not/exist.wav");
+        let duration = chunking_duration_for(missing, 123.4);
+        assert_eq!(duration, 123.4);
+    }
+
+    #[test]
+    fn test_chunking_duration_for_uses_wav_duration_when_readable() {
+        use crate::recording::audio::write_wav_file;
+
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "thoughtcast_retranscribe_test_{}.wav",
+            std::process::id()
+        ));
+
+        // 1 second of silence at 48 kHz — apparent duration should be 1.0s.
+        let samples = vec![0.0f32; 48_000];
+        write_wav_file(&samples, &path, 48_000).expect("write should succeed");
+
+        // session.duration intentionally wrong (mimics pre-fix mislabelling).
+        let duration = chunking_duration_for(&path, 0.918);
+        assert!(
+            (duration - 1.0).abs() < 0.001,
+            "expected ~1.0s from WAV header, got {}",
+            duration
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_prepare_retranscribe_input_requires_config_for_non_wav() {
+        let audio = Path::new("/data/audio/2026-05-14_20-06-16.m4a");
+        let err = prepare_retranscribe_input(audio, "2026-05-14_20-06-16", None)
+            .expect_err("non-WAV without config should fail");
+        assert!(
+            err.contains("FFmpeg path is required"),
+            "error should explain ffmpeg requirement, got: {}",
+            err
+        );
+    }
+}

--- a/src-tauri/src/recording/session/transcription_orchestration.rs
+++ b/src-tauri/src/recording/session/transcription_orchestration.rs
@@ -1,0 +1,316 @@
+use crate::recording::compression::{
+    run_post_transcription_compression, SessionAudioCompressedEvent,
+};
+use crate::recording::models::{AppConfig, Session};
+use crate::recording::state::{RecordingStatus, SharedRecordingState};
+use crate::recording::transcription::{
+    transcribe_in_chunks, transcribe_with_whisper, ChunkingTelemetry,
+};
+use crate::recording::utils::copy_to_clipboard;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+
+/// Per-chunk progress for a chunked transcription. `current` is 1-indexed.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChunkProgressEvent {
+    pub session_id: String,
+    pub current: u32,
+    pub total: u32,
+}
+
+/// Result of async transcription for event emission. Shared between the
+/// initial-recording (`orchestrate_async_transcription`) and retranscription
+/// (`retranscription::orchestrate_async_retranscription`) pipelines so both
+/// emit the same Tauri events.
+pub enum TranscriptionResult {
+    Success(Session),
+    Progress(ChunkProgressEvent),
+    Compressed(SessionAudioCompressedEvent),
+    Error { session_id: String, error: String },
+}
+
+/// Orchestrate async transcription in background thread.
+///
+/// Spawns a background thread that:
+/// 1. Processes transcription
+/// 2. Updates session with results
+/// 3. Updates recording state to idle
+/// 4. Emits Tauri events with results
+///
+/// This is domain orchestration logic extracted from the Tauri command layer.
+///
+/// # Arguments
+/// * `state` - Shared recording state for status updates
+/// * `session_id` - ID of session to transcribe
+/// * `audio_path` - Path to audio file
+/// * `event_emitter` - Callback to emit Tauri events (injected dependency)
+pub fn orchestrate_async_transcription<F>(
+    state: SharedRecordingState,
+    session_id: String,
+    audio_path: PathBuf,
+    event_emitter: F,
+) where
+    F: Fn(TranscriptionResult) + Send + Sync + 'static,
+{
+    // Mark the session as in-flight for transcription before the worker thread
+    // starts so the batch-compression worker won't race it.
+    if let Ok(mut state_guard) = state.lock() {
+        state_guard.transcribing_session_ids.insert(session_id.clone());
+    }
+
+    thread::spawn(move || {
+        // Arc the emitter so the progress callback (which fires repeatedly
+        // during chunked transcription) can share it with the success/error
+        // call paths.
+        let emitter = Arc::new(event_emitter);
+        let progress_session_id = session_id.clone();
+        let progress_emitter = Arc::clone(&emitter);
+        let progress_fn = move |current: u32, total: u32| {
+            progress_emitter(TranscriptionResult::Progress(ChunkProgressEvent {
+                session_id: progress_session_id.clone(),
+                current,
+                total,
+            }));
+        };
+
+        let result = process_transcription_async(audio_path, session_id.clone(), &progress_fn);
+
+        // Update state to idle regardless of success/failure
+        if let Ok(mut state_guard) = state.lock() {
+            state_guard.status = RecordingStatus::Idle;
+            state_guard.transcribing_session_ids.remove(&session_id);
+        }
+
+        // Emit event via injected callback
+        match result {
+            Ok(session) => {
+                let audio_path_for_compression = session.audio_path.clone();
+                let session_id_for_compression = session.id.clone();
+                emitter(TranscriptionResult::Success(session));
+
+                // Best-effort post-transcription compression. Runs on this same
+                // background thread after the success event has already fired
+                // so the UI gets a transcript first and then a follow-up
+                // compression event if compression was enabled.
+                match run_post_transcription_compression(
+                    &session_id_for_compression,
+                    &audio_path_for_compression,
+                ) {
+                    Ok(Some(compression_event)) => {
+                        emitter(TranscriptionResult::Compressed(compression_event));
+                    }
+                    Ok(None) => {
+                        // Compression disabled — nothing to do.
+                    }
+                    Err(e) => {
+                        // Non-fatal: WAV stays put, session row remains valid.
+                        log::warn!(
+                            "Post-transcription compression failed for {}: {}",
+                            session_id_for_compression,
+                            e
+                        );
+                    }
+                }
+            }
+            Err(error) => emitter(TranscriptionResult::Error {
+                session_id,
+                error,
+            }),
+        }
+    });
+}
+
+/// Process transcription asynchronously and update the session row.
+///
+/// Routes through the chunked path when the recording is long enough and
+/// chunking is enabled; otherwise runs single-shot whisper.cpp. Copies the
+/// transcript to the clipboard on success. Returns the updated session.
+///
+/// `on_progress(current, total)` fires per chunk on the chunked path. The
+/// single-shot path does not emit progress (the UI falls back to its
+/// time-based estimate).
+pub fn process_transcription_async(
+    audio_path: PathBuf,
+    session_id: String,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> Result<Session, String> {
+    use crate::recording::session::storage::{load_sessions, save_sessions};
+
+    let mut index = load_sessions()?;
+    let audio_duration = index
+        .sessions
+        .iter()
+        .find(|s| s.id == session_id)
+        .map(|s| s.duration)
+        .unwrap_or(0.0);
+
+    // Single config load: drives both the route decision (chunking vs
+    // single-shot) and the model-path telemetry the estimator needs.
+    let config = crate::recording::load_config().ok();
+
+    let transcription_start = Instant::now();
+    let (transcript_path, preview, clipboard_copied, chunking_telemetry) = run_transcription_route(
+        &audio_path,
+        &session_id,
+        audio_duration,
+        config.as_ref(),
+        on_progress,
+    );
+    let transcription_elapsed = transcription_start.elapsed().as_secs_f64();
+
+    let model_path = config.as_ref().map(|c| c.model_path.clone());
+
+    let updated_session = {
+        let session = index
+            .sessions
+            .iter_mut()
+            .find(|s| s.id == session_id)
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        session.transcript_path = transcript_path.clone();
+        session.preview = preview;
+        session.clipboard_copied = clipboard_copied;
+
+        if !transcript_path.is_empty() && audio_duration > 0.0 {
+            session.transcription_time_seconds = Some(transcription_elapsed);
+            session.model_path = model_path;
+        }
+        if let Some(telemetry) = chunking_telemetry {
+            session.chunking_analysis_seconds = Some(telemetry.analysis_seconds);
+            session.chunk_count = Some(telemetry.chunk_count);
+            session.chunking_used_fallback = Some(telemetry.used_fallback);
+        }
+
+        session.clone()
+    };
+
+    save_sessions(&index)?;
+
+    Ok(updated_session)
+}
+
+/// Decide between the chunked and single-shot transcription paths and run
+/// the chosen one. Returns the same shape the legacy single-shot path
+/// produced, plus optional chunking telemetry to persist on the session.
+///
+/// Chunking is silently disabled when FFmpeg is missing or unconfigured —
+/// the user shouldn't get a transcription failure just because chunking
+/// can't run. The path falls back to a normal single-shot transcription
+/// in that case (PRD edge case 7).
+///
+/// `pub(crate)` so the retranscription pipeline can reuse the same routing
+/// logic without duplicating the chunk/single-shot decision.
+pub(crate) fn run_transcription_route(
+    audio_path: &Path,
+    session_id: &str,
+    audio_duration_sec: f64,
+    config: Option<&AppConfig>,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> (String, String, bool, Option<ChunkingTelemetry>) {
+    if let Some(cfg) = config {
+        if should_use_chunking(cfg, audio_duration_sec) {
+            return run_chunked_path(audio_path, session_id, audio_duration_sec, cfg, on_progress);
+        }
+    }
+
+    let (path, preview, copied) = process_transcription(audio_path, session_id);
+    (path, preview, copied, None)
+}
+
+fn should_use_chunking(config: &AppConfig, audio_duration_sec: f64) -> bool {
+    if !config.audio_chunking.enabled {
+        return false;
+    }
+    let ffmpeg = config.ffmpeg_path.trim();
+    if ffmpeg.is_empty() {
+        return false;
+    }
+    if !Path::new(ffmpeg).exists() {
+        log::warn!(
+            "Chunking enabled but FFmpeg not found at '{}' — running single-shot transcription instead",
+            ffmpeg
+        );
+        return false;
+    }
+    audio_duration_sec > config.audio_chunking.min_chunk_duration_sec
+}
+
+fn run_chunked_path(
+    audio_path: &Path,
+    session_id: &str,
+    audio_duration_sec: f64,
+    config: &AppConfig,
+    on_progress: &(dyn Fn(u32, u32) + Sync),
+) -> (String, String, bool, Option<ChunkingTelemetry>) {
+    match transcribe_in_chunks(audio_path, session_id, audio_duration_sec, config, on_progress) {
+        Ok(outcome) => {
+            let preview = generate_preview(&outcome.transcript_text);
+            let clipboard_copied = if !outcome.transcript_text.is_empty() {
+                copy_to_clipboard(&outcome.transcript_text).is_ok()
+            } else {
+                false
+            };
+            (
+                outcome.transcript_path,
+                preview,
+                clipboard_copied,
+                Some(outcome.telemetry),
+            )
+        }
+        Err(e) => {
+            log::error!("Chunked transcription failed: {}", e);
+            (
+                String::new(),
+                format!("Transcription failed: {}", e),
+                false,
+                None,
+            )
+        }
+    }
+}
+
+/// Process transcription and handle result.
+///
+/// Returns (transcript_path, preview, clipboard_copied).
+fn process_transcription(audio_path: &Path, id: &str) -> (String, String, bool) {
+    match transcribe_with_whisper(audio_path, id) {
+        Ok((path, text)) => {
+            let preview = generate_preview(&text);
+
+            let clipboard_copied = if !text.is_empty() {
+                match copy_to_clipboard(&text) {
+                    Ok(_) => {
+                        println!("Transcript copied to clipboard");
+                        true
+                    }
+                    Err(e) => {
+                        eprintln!("Failed to copy to clipboard: {}", e);
+                        false
+                    }
+                }
+            } else {
+                false
+            };
+
+            (path, preview, clipboard_copied)
+        }
+        Err(e) => {
+            // Log error but don't fail the recording
+            eprintln!("Transcription failed: {}", e);
+            (String::new(), format!("Transcription failed: {}", e), false)
+        }
+    }
+}
+
+/// Generate a preview string from transcript text.
+fn generate_preview(text: &str) -> String {
+    if text.len() > 100 {
+        format!("{}...", &text[..100])
+    } else if text.is_empty() {
+        "No transcript".to_string()
+    } else {
+        text.to_string()
+    }
+}

--- a/src-tauri/src/recording/state.rs
+++ b/src-tauri/src/recording/state.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 /// Recording status representing the current state of the recording session
@@ -10,6 +11,60 @@ pub enum RecordingStatus {
     Recording,
     Paused,
     Processing,
+}
+
+/// The audio-capture thread's published view of a recording session.
+///
+/// These four fields are produced by the capture thread (`audio/capture.rs`)
+/// and consumed by lifecycle / failure / Tauri-command paths on other
+/// threads. Grouping them in one struct makes the producer/consumer split
+/// explicit and lets reset paths use `take_for_reset()` instead of touching
+/// four separate fields by hand.
+#[derive(Debug, Default)]
+pub struct CaptureChannel {
+    /// Device sample rate (Hz) for the current capture, populated by the audio
+    /// thread once it has queried the input device. The WAV writer reads this
+    /// at save time so the file's header matches the rate the samples were
+    /// actually captured at — labelling them 44.1 kHz when CPAL ran at 48 kHz
+    /// time-stretches playback by ~8.8% and silently truncates downstream
+    /// chunked transcription.
+    pub sample_rate: Option<u32>,
+    /// Set by the CPAL stream error callback (or by capture-thread init
+    /// failures) when audio capture dies mid-session. The capture loop polls
+    /// this every 100 ms and, when populated, breaks out to run the partial-
+    /// save / failure-event path. Cleared on next `start_capture`.
+    pub capture_error: Option<String>,
+    /// Path of the in-flight WAV the capture thread is streaming samples to.
+    /// `Some` while a recording is active or paused; `None` otherwise.
+    ///
+    /// Capture failures, normal stops, and cancels all consult this so they
+    /// can finalize / move / delete the file in one place. The path lives
+    /// under `audio/.in-flight/<id>.wav` until Stop renames it to the
+    /// permanent `audio/<id>.wav`.
+    pub in_flight_audio_path: Option<PathBuf>,
+    /// Total seconds of audio durably committed to the in-flight WAV's data
+    /// chunk (and reflected in its on-disk header). Published by the capture
+    /// thread every few seconds so the reconciliation tick can surface a
+    /// "Saved through" trust signal in the UI — even mid-recording, the user
+    /// sees that their audio is on disk, not just in RAM.
+    pub flushed_through_seconds: Option<f64>,
+}
+
+impl CaptureChannel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Reset all four fields and return the in-flight WAV path so the caller
+    /// can clean it up (delete on cancel, rename on stop/failure). The path
+    /// is taken with `Option::take` so a second call returns `None`.
+    pub fn take_for_reset(&mut self) -> Option<PathBuf> {
+        let path = self.in_flight_audio_path.take();
+        self.sample_rate = None;
+        self.capture_error = None;
+        self.flushed_through_seconds = None;
+        path
+    }
 }
 
 /// The state of an active recording session
@@ -28,13 +83,9 @@ pub struct RecordingState {
     pub total_paused_duration_ms: i64,
     pub active_session_id: Option<String>,
     pub transcribing_session_ids: std::collections::HashSet<String>,
-    /// Device sample rate (Hz) for the current capture, populated by the audio
-    /// thread once it has queried the input device. The WAV writer reads this
-    /// at save time so the file's header matches the rate the samples were
-    /// actually captured at — labelling them 44.1 kHz when CPAL ran at 48 kHz
-    /// time-stretches playback by ~8.8% and silently truncates downstream
-    /// chunked transcription.
-    pub sample_rate: Option<u32>,
+    /// Capture-thread-published state (sample rate, in-flight WAV, etc.). See
+    /// `CaptureChannel` for the producer/consumer rationale.
+    pub capture: CaptureChannel,
 }
 
 impl RecordingState {
@@ -47,7 +98,7 @@ impl RecordingState {
             total_paused_duration_ms: 0,
             active_session_id: None,
             transcribing_session_ids: std::collections::HashSet::new(),
-            sample_rate: None,
+            capture: CaptureChannel::new(),
         }
     }
 

--- a/src-tauri/src/shortcuts/registrar.rs
+++ b/src-tauri/src/shortcuts/registrar.rs
@@ -71,6 +71,16 @@ pub fn unregister_record_shortcut(app: &AppHandle) -> Result<(), String> {
 /// `recordingStatus`) are expected to register only while a recording is
 /// active, then unregister once the take ends — keeping the OS-global Escape
 /// binding from clobbering text inputs in other apps when ThoughtCast is idle.
+///
+/// **Focus-gated**: the registered handler additionally checks that the
+/// ThoughtCast window has keyboard focus before emitting the cancel event.
+/// `tauri-plugin-global-shortcut` installs an OS-wide keyboard hook — without
+/// this gate, hitting Escape *anywhere* on the OS (closing a browser modal,
+/// dismissing an IDE autocomplete, exiting fullscreen video) would destroy the
+/// in-flight recording. The user lost 13 minutes of audio to exactly this on
+/// 2026-05-25. The focus check costs one IPC-free `is_focused()` call per key
+/// press and matches the user's mental model of "this shortcut applies to
+/// ThoughtCast."
 pub fn register_cancel_shortcut(app: &AppHandle, accelerator: &str) -> Result<(), String> {
     ensure_cancel_slot(app);
     let slot = &app.state::<CancelShortcutSlot>().0;
@@ -81,16 +91,33 @@ pub fn register_cancel_shortcut(app: &AppHandle, accelerator: &str) -> Result<()
     let handler_app = app.clone();
     app.global_shortcut()
         .on_shortcut(shortcut, move |_app, _short, event| {
-            // We only emit on press — cancel has no "release" semantic.
-            if event.state() == ShortcutState::Pressed {
-                let _ = handler_app.emit(
-                    CANCEL_SHORTCUT_EVENT,
-                    ShortcutEventPayload { state: "pressed" },
-                );
+            if event.state() != ShortcutState::Pressed {
+                return;
             }
+            if !thoughtcast_window_is_focused(&handler_app) {
+                log::info!(
+                    "Cancel shortcut press swallowed — ThoughtCast window is not focused"
+                );
+                return;
+            }
+            let _ = handler_app.emit(
+                CANCEL_SHORTCUT_EVENT,
+                ShortcutEventPayload { state: "pressed" },
+            );
         })
         .map_err(|e| format!("Failed to register cancel shortcut '{}': {}", accelerator, e))?;
     Ok(())
+}
+
+/// True only when the ThoughtCast main window currently has keyboard focus.
+/// Conservative: any error (window missing, focus query fails) returns false
+/// so the worst case is "shortcut quietly does nothing" rather than "cancel
+/// fires from another app."
+fn thoughtcast_window_is_focused(app: &AppHandle) -> bool {
+    let Some(window) = app.get_webview_window("main") else {
+        return false;
+    };
+    window.is_focused().unwrap_or(false)
 }
 
 pub fn unregister_cancel_shortcut(app: &AppHandle) -> Result<(), String> {

--- a/src/api/RecordingFailureEvents.ts
+++ b/src/api/RecordingFailureEvents.ts
@@ -1,0 +1,28 @@
+/**
+ * Tauri event emitted by the audio capture thread when the stream fails
+ * mid-recording or fails to initialize.
+ *
+ * Lives in `src/api/` (not `src/features/recording/`) because the workflow
+ * hook in `src/app/` subscribes to it. Mirrors the layout of
+ * `TranscriptionEvents.ts` and `CompressionEvents.ts`.
+ *
+ * The string literal matches the event name emitted from
+ * `src-tauri/src/lib.rs::start_recording`.
+ */
+import { Session } from "./Session";
+
+export const RECORDING_CAPTURE_FAILED = "recording-capture-failed" as const;
+
+/**
+ * Payload mirrors Rust's `RecordingCaptureFailedEvent` in
+ * `src-tauri/src/recording/audio/failure.rs`.
+ *
+ * `recovered_session` is `null` when the failure happened before any audio
+ * could be captured (or the partial save itself failed) — the UI should still
+ * surface the warning so the user knows recording is no longer active.
+ */
+export interface RecordingCaptureFailedPayload {
+  reason: string;
+  partial_duration_seconds: number;
+  recovered_session: Session | null;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,6 +16,8 @@ export type {
   CompressionBatchProgressPayload,
   CompressionBatchCompletePayload,
 } from './CompressionEvents';
+export { RECORDING_CAPTURE_FAILED } from './RecordingFailureEvents';
+export type { RecordingCaptureFailedPayload } from './RecordingFailureEvents';
 export type {
   TranscriptionEstimate,
   TranscriptionProgress,

--- a/src/api/services/RecordingService.test.ts
+++ b/src/api/services/RecordingService.test.ts
@@ -115,6 +115,31 @@ describe('TauriRecordingService', () => {
       await expect(service.getAudioLevels()).rejects.toThrow('Failed to get audio levels');
     });
   });
+
+  describe('getRecordingFlushedThroughSeconds', () => {
+    it('returns the durably-flushed duration', async () => {
+      mockInvoke.mockResolvedValue(123.45);
+
+      const result = await service.getRecordingFlushedThroughSeconds();
+
+      expect(mockInvoke).toHaveBeenCalledWith(
+        'get_recording_flushed_through_seconds',
+        undefined
+      );
+      expect(result).toBe(123.45);
+    });
+
+    it('returns null when no recording is active', async () => {
+      mockInvoke.mockResolvedValue(null);
+      const result = await service.getRecordingFlushedThroughSeconds();
+      expect(result).toBeNull();
+    });
+
+    it('wraps backend errors in ApiError', async () => {
+      mockInvoke.mockRejectedValue(new Error('Backend gone'));
+      await expect(service.getRecordingFlushedThroughSeconds()).rejects.toThrow(ApiError);
+    });
+  });
 });
 
 describe('MockRecordingService', () => {

--- a/src/api/services/RecordingService.ts
+++ b/src/api/services/RecordingService.ts
@@ -56,6 +56,18 @@ export interface IRecordingService {
    * @throws {ApiError} If audio level retrieval fails
    */
   getAudioLevels(): Promise<number[]>;
+
+  /**
+   * Total seconds of audio durably committed to the in-flight WAV's on-disk
+   * header. Returns `null` when no recording is active or the streaming writer
+   * has not yet flushed.
+   *
+   * The UI uses this to render a "Saved through MM:SS" trust signal so the
+   * user can tell at a glance that a long recording is surviving on disk —
+   * not just in RAM.
+   * @throws {ApiError} If the call fails
+   */
+  getRecordingFlushedThroughSeconds(): Promise<number | null>;
 }
 
 /**
@@ -133,6 +145,15 @@ export class TauriRecordingService implements IRecordingService {
       undefined,
       'Failed to get audio levels',
       'AUDIO_LEVELS_FAILED'
+    );
+  }
+
+  async getRecordingFlushedThroughSeconds(): Promise<number | null> {
+    return wrapTauriInvoke<number | null>(
+      'get_recording_flushed_through_seconds',
+      undefined,
+      'Failed to get streamed audio durability',
+      'RECORDING_FLUSH_STATUS_FAILED'
     );
   }
 }
@@ -301,6 +322,19 @@ export class MockRecordingService implements IRecordingService {
       const noise = Math.random() * 0.3;
       return Math.min(1.0, wave * 0.6 + noise * 0.4);
     });
+  }
+
+  async getRecordingFlushedThroughSeconds(): Promise<number | null> {
+    await new Promise(resolve => setTimeout(resolve, 10));
+    if (this.status === 'idle' || !this.recordingStartTime) {
+      return null;
+    }
+    // Mock behavior: pretend the streaming writer is ~1s behind the timer.
+    const elapsedMs =
+      this.mockDuration > 0
+        ? this.mockDuration * 1000
+        : Date.now() - this.recordingStartTime - this.totalPausedDurationMs;
+    return Math.max(0, elapsedMs / 1000 - 1.0);
   }
 
   /**

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -29,6 +29,7 @@ function App() {
     recordingStatusRef,
     isProcessing,
     recordingDuration,
+    flushedThroughSeconds,
     status,
     selectedSession,
     handleStartRecording,
@@ -86,6 +87,7 @@ function App() {
         recordingStatus={recordingStatus}
         isProcessing={isProcessing}
         recordingDuration={recordingDuration}
+        flushedThroughSeconds={flushedThroughSeconds}
         status={status}
         onStartRecording={handleStartRecording}
         onPauseRecording={handlePauseRecording}

--- a/src/app/useRecordingWorkflow.test.ts
+++ b/src/app/useRecordingWorkflow.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { determineRecordingStatus, findSessionById, autoSelectFirstSession, useRecordingWorkflow } from './useRecordingWorkflow';
-import { Session } from '../api';
+import { useRecordingWorkflow } from './useRecordingWorkflow';
+import {
+  determineRecordingStatus,
+  findSessionById,
+  autoSelectFirstSession,
+  handleRecordingCaptureFailed,
+} from '../features/recording/workflowEventHandlers';
+import { Session, RecordingCaptureFailedPayload } from '../api';
 import { ApiProvider } from '../api/ApiContext';
 import React from 'react';
 
@@ -190,6 +196,67 @@ describe('autoSelectFirstSession', () => {
   });
 });
 
+describe('handleRecordingCaptureFailed', () => {
+  function makeCallbacks() {
+    const calls = {
+      setStatus: vi.fn(),
+      setRecordingStatus: vi.fn(),
+      setIsProcessing: vi.fn(),
+      setRecordingDuration: vi.fn(),
+      setSelectedId: vi.fn(),
+      loadSessions: vi.fn().mockResolvedValue(undefined),
+    };
+    return calls;
+  }
+
+  const recoveredSession: Session = {
+    id: 'recovered-1',
+    timestamp: '2026-05-17T14:22:00Z',
+    duration: 1985.6,
+    audio_path: 'audio/recovered-1.wav',
+    preview: '⚠️ Recording ended unexpectedly — audio saved, transcribe manually',
+    clipboard_copied: false,
+  };
+
+  it('shows the saved-audio message and selects the recovered session', () => {
+    const cb = makeCallbacks();
+    const payload: RecordingCaptureFailedPayload = {
+      reason: 'Audio stream error: Device disconnected',
+      partial_duration_seconds: 1985.6,
+      recovered_session: recoveredSession,
+    };
+    handleRecordingCaptureFailed(payload, cb);
+
+    expect(cb.setRecordingStatus).toHaveBeenCalledWith('idle');
+    expect(cb.setIsProcessing).toHaveBeenCalledWith(false);
+    expect(cb.setRecordingDuration).toHaveBeenCalledWith(0);
+    expect(cb.setStatus).toHaveBeenCalledTimes(1);
+    const message = cb.setStatus.mock.calls[0][0];
+    expect(message).toContain('Saved');
+    expect(message).toContain('~33m 06s of audio');
+    expect(message).toContain('Device disconnected');
+    expect(cb.setSelectedId).toHaveBeenCalledWith('recovered-1');
+    expect(cb.loadSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the no-audio-recovered message when partial save failed', () => {
+    const cb = makeCallbacks();
+    const payload: RecordingCaptureFailedPayload = {
+      reason: 'No microphone access',
+      partial_duration_seconds: 0,
+      recovered_session: null,
+    };
+    handleRecordingCaptureFailed(payload, cb);
+
+    expect(cb.setRecordingStatus).toHaveBeenCalledWith('idle');
+    expect(cb.setSelectedId).not.toHaveBeenCalled();
+    const message = cb.setStatus.mock.calls[0][0];
+    expect(message).toContain('no audio recovered');
+    expect(message).toContain('No microphone access');
+    expect(cb.loadSessions).toHaveBeenCalledTimes(1);
+  });
+});
+
 // ===== Hook Tests =====
 
 describe('useRecordingWorkflow', () => {
@@ -204,6 +271,8 @@ describe('useRecordingWorkflow', () => {
     resumeRecording: vi.fn(),
     cancelRecording: vi.fn(),
     getRecordingDuration: vi.fn(),
+    getRecordingStatus: vi.fn(),
+    getRecordingFlushedThroughSeconds: vi.fn(),
   };
 
   const mockClipboardService = {
@@ -257,6 +326,15 @@ describe('useRecordingWorkflow', () => {
     mockRecordingService.resumeRecording.mockClear();
     mockRecordingService.cancelRecording.mockClear();
     mockRecordingService.getRecordingDuration.mockClear();
+    mockRecordingService.getRecordingStatus.mockClear();
+    mockRecordingService.getRecordingFlushedThroughSeconds.mockClear();
+    // Default backend status agrees with the frontend's optimistic state so
+    // existing tests don't see spurious drift corrections. Specific
+    // reconciliation tests override this per-case.
+    mockRecordingService.getRecordingStatus.mockResolvedValue('idle');
+    // Streaming-writer trust signal: null while not recording, mock pretends
+    // the writer hasn't flushed anything yet.
+    mockRecordingService.getRecordingFlushedThroughSeconds.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -296,6 +374,10 @@ describe('useRecordingWorkflow', () => {
 
   it('should start recording successfully', async () => {
     mockRecordingService.startRecording.mockResolvedValue(undefined);
+    // Backend mirrors the optimistic frontend transition so the
+    // reconciliation tick (now running while in recording/paused) finds no
+    // drift to correct.
+    mockRecordingService.getRecordingStatus.mockResolvedValue('recording');
     const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
 
     await waitFor(() => {
@@ -346,6 +428,9 @@ describe('useRecordingWorkflow', () => {
     };
 
     mockRecordingService.stopRecording.mockResolvedValue(initialSession);
+    // After stop the backend transitions through processing; the
+    // reconciliation tick no-ops on `'processing'`, so a fixed mock is fine.
+    mockRecordingService.getRecordingStatus.mockResolvedValue('processing');
     const updatedSessions = [...mockSessions, completedSession];
 
     // Return original sessions first, then with processing session, then with completed
@@ -414,6 +499,7 @@ describe('useRecordingWorkflow', () => {
   it('should update recording duration while recording', async () => {
     mockRecordingService.startRecording.mockResolvedValue(undefined);
     mockRecordingService.getRecordingDuration.mockResolvedValue(5.5);
+    mockRecordingService.getRecordingStatus.mockResolvedValue('recording');
 
     const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
 
@@ -500,6 +586,9 @@ describe('useRecordingWorkflow', () => {
     it('does not reset a paused recording when a stale completion arrives', async () => {
       mockRecordingService.startRecording.mockResolvedValue(undefined);
       mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+      // Backend agrees with the optimistic transition so the new
+      // reconciliation tick stays silent during the stale-event scenario.
+      mockRecordingService.getRecordingStatus.mockResolvedValue('paused');
 
       const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
 
@@ -536,6 +625,7 @@ describe('useRecordingWorkflow', () => {
 
     it('does not reset an active recording when a stale completion arrives', async () => {
       mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.getRecordingStatus.mockResolvedValue('recording');
 
       const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
 
@@ -565,6 +655,7 @@ describe('useRecordingWorkflow', () => {
     it('does not reset a paused recording when a stale transcription error arrives', async () => {
       mockRecordingService.startRecording.mockResolvedValue(undefined);
       mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+      mockRecordingService.getRecordingStatus.mockResolvedValue('paused');
 
       const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
 
@@ -601,6 +692,7 @@ describe('useRecordingWorkflow', () => {
     it('still refreshes the session list when a stale completion arrives', async () => {
       mockRecordingService.startRecording.mockResolvedValue(undefined);
       mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+      mockRecordingService.getRecordingStatus.mockResolvedValue('paused');
 
       const refreshedSessions = [...mockSessions, staleCompletedSession];
       mockSessionService.getSessions
@@ -633,6 +725,161 @@ describe('useRecordingWorkflow', () => {
         expect(result.current.sessions).toEqual(refreshedSessions);
       });
       expect(result.current.recordingStatus).toBe('paused');
+    });
+  });
+
+  // Reconciliation against the backend's authoritative recording status: the
+  // PRD requires that whatever async path drops the frontend out of sync,
+  // backend truth pulls it back. These tests target the polling tick and the
+  // mount-time one-shot.
+  describe('backend status reconciliation', () => {
+    it('restores the recording UI on mount when backend is still capturing', async () => {
+      // Simulate a window reload while a recording was active: backend reports
+      // `'recording'`, frontend starts at `'idle'`. The mount-time
+      // reconciliation should restore the active state.
+      mockRecordingService.getRecordingStatus.mockResolvedValue('recording');
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.recordingStatus).toBe('recording');
+        expect(result.current.status).toBe('⏺️ Recording...');
+      });
+    });
+
+    it('restores the paused UI on mount when backend reports paused', async () => {
+      mockRecordingService.getRecordingStatus.mockResolvedValue('paused');
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.recordingStatus).toBe('paused');
+        expect(result.current.status).toBe('⏸️ Recording paused');
+      });
+    });
+
+    it('reconciles drift discovered during the active-state tick (paused -> recording)', async () => {
+      // Frontend in `paused`, but the backend has somehow moved to `recording`
+      // (e.g. an out-of-band resume). The 500 ms tick should mirror backend.
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.pauseRecording.mockResolvedValue(undefined);
+      mockRecordingService.getRecordingDuration.mockResolvedValue(0);
+
+      // Mount agrees with idle, then we transition through start → pause...
+      mockRecordingService.getRecordingStatus.mockResolvedValueOnce('idle');
+      mockRecordingService.getRecordingStatus.mockResolvedValueOnce('paused');
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      await act(async () => { await Promise.resolve(); });
+      await act(async () => { await result.current.handleStartRecording(); });
+      await act(async () => { await result.current.handlePauseRecording(); });
+
+      expect(result.current.recordingStatus).toBe('paused');
+
+      // ...and now backend has drifted to `'recording'`. Subsequent polls
+      // should reconcile.
+      mockRecordingService.getRecordingStatus.mockResolvedValue('recording');
+
+      await waitFor(
+        () => {
+          expect(result.current.recordingStatus).toBe('recording');
+          expect(result.current.status).toBe('⏺️ Recording...');
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it('announces unexpected end when backend goes idle while frontend believes recording', async () => {
+      // The PRD case where capture ended out from under the UI: backend `idle`
+      // while the frontend thinks `recording`. Reconciliation must surface a
+      // warning, not silently pretend capture is still alive.
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.getRecordingDuration.mockResolvedValue(0);
+      // First poll on mount agrees with idle, second (after start) returns
+      // `'recording'` so the initial tick does not announce. Then backend
+      // drops to `'idle'`.
+      mockRecordingService.getRecordingStatus
+        .mockResolvedValueOnce('idle')
+        .mockResolvedValueOnce('recording')
+        .mockResolvedValue('idle');
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      await act(async () => { await Promise.resolve(); });
+      await act(async () => { await result.current.handleStartRecording(); });
+      expect(result.current.recordingStatus).toBe('recording');
+
+      await waitFor(
+        () => {
+          expect(result.current.recordingStatus).toBe('idle');
+          expect(result.current.status).toBe('⚠️ Recording ended unexpectedly');
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it('handles recording-capture-failed event by resetting state and surfacing a warning', async () => {
+      mockRecordingService.startRecording.mockResolvedValue(undefined);
+      mockRecordingService.getRecordingStatus.mockResolvedValue('recording');
+
+      const recovered: Session = {
+        id: 'recovered-session',
+        timestamp: '2026-05-17T14:22:00Z',
+        duration: 95.0,
+        audio_path: 'audio/recovered-session.wav',
+        preview: '⚠️ Recording ended unexpectedly — audio saved, transcribe manually',
+        clipboard_copied: false,
+      };
+      mockSessionService.getSessions
+        .mockResolvedValueOnce({ sessions: mockSessions })
+        .mockResolvedValue({ sessions: [...mockSessions, recovered] });
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      await act(async () => { await Promise.resolve(); });
+      await act(async () => { await result.current.handleStartRecording(); });
+      expect(result.current.recordingStatus).toBe('recording');
+
+      // Backend's audio thread emits the capture-failed event.
+      await act(async () => {
+        emitMockEvent('recording-capture-failed', {
+          reason: 'Audio stream error: Device disconnected',
+          partial_duration_seconds: 95.4,
+          recovered_session: recovered,
+        });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.recordingStatus).toBe('idle');
+        expect(result.current.status).toContain('Recording stopped unexpectedly');
+        expect(result.current.status).toContain('Device disconnected');
+        expect(result.current.selectedId).toBe('recovered-session');
+      });
+    });
+
+    it('no drift = no UI churn (idle ↔ idle stays silent)', async () => {
+      mockRecordingService.getRecordingStatus.mockResolvedValue('idle');
+
+      const { result } = renderHook(() => useRecordingWorkflow(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.sessions).toEqual(mockSessions);
+      });
+
+      // No spurious status mutation from the mount-time check.
+      expect(result.current.recordingStatus).toBe('idle');
+      expect(result.current.status).toBe('Ready to record');
     });
   });
 });

--- a/src/app/useRecordingWorkflow.ts
+++ b/src/app/useRecordingWorkflow.ts
@@ -6,137 +6,35 @@ import {
   TranscriptionErrorEvent,
   SESSION_AUDIO_COMPRESSED,
   SessionAudioCompressedPayload,
+  RECORDING_CAPTURE_FAILED,
+  RecordingCaptureFailedPayload,
   useApi,
 } from '../api';
 import { listen } from '@tauri-apps/api/event';
 import { logger } from '../shared/utils/logger';
 import { useDocumentActivity } from '../shared/utils/useDocumentActivity';
 import { useRecordingCues } from '../features/audio-feedback/useRecordingCues';
+import {
+  detectStatusDrift,
+  applyDriftAction,
+  DriftCallbacks,
+} from '../features/recording/recordingStatusDrift';
+import {
+  autoSelectFirstSession,
+  findSessionById,
+  handleRecordingCaptureFailed,
+  handleTranscriptionComplete,
+  handleTranscriptionError,
+} from '../features/recording/workflowEventHandlers';
 
 /**
- * Determines appropriate status message based on recording result
+ * Cadence (ms) for the idle-state drift watcher. While the frontend believes
+ * recording is `'idle'`, we still want to catch the case where the backend is
+ * actually mid-capture (the reported "top bar reverted" symptom) — but we
+ * don't need the 500 ms timer cadence for that. 3 s keeps the heartbeat cheap
+ * while shortening any drift window the user might notice.
  */
-export function determineRecordingStatus(session: Session): string {
-  if (session.transcript_path && session.transcript_path.length > 0) {
-    if (session.clipboard_copied) {
-      return "✅ Transcript copied to clipboard!";
-    }
-    return "⚠️ Transcription complete (clipboard copy failed - use Copy button)";
-  }
-  return "⚠️ Recording saved (transcription failed - check Whisper setup)";
-}
-
-/**
- * Finds session by ID or returns null
- */
-export function findSessionById(sessions: Session[], id: string | null): Session | null {
-  if (!id) return null;
-  return sessions.find(s => s.id === id) || null;
-}
-
-/**
- * Selects the first session if none selected and sessions available
- */
-export function autoSelectFirstSession(
-  sessions: Session[],
-  currentSelectedId: string | null
-): string | null {
-  if (sessions.length > 0 && !currentSelectedId) {
-    return sessions[0].id;
-  }
-  return currentSelectedId;
-}
-
-/**
- * Handle transcription completion event
- *
- * Background transcriptions (a prior recording or a user-triggered retranscribe)
- * can finish while the user is already in the middle of a *new* recording —
- * including paused. Without `getRecordingStatus`, this handler would
- * unconditionally flip `recordingStatus` to `'idle'` and wipe the in-progress
- * recording out of the UI even though the backend is still capturing it. We
- * gate the workflow-state mutations on actually being in `'processing'`; if
- * we're not, the event corresponds to background work and we only refresh
- * the session list (so the completed transcript appears in the sidebar).
- */
-export function handleTranscriptionComplete(
-  session: Session,
-  callbacks: {
-    setStatus: (status: string) => void;
-    setRecordingStatus: (status: RecordingStatus) => void;
-    setIsProcessing: (processing: boolean) => void;
-    loadSessions: () => Promise<void>;
-    playReadyCue: () => void;
-    getRecordingStatus: () => RecordingStatus;
-  }
-): void {
-  logger.info('Transcription completed:', session.id);
-
-  // Always refresh the session list so the completed transcript shows up,
-  // even if we shouldn't touch the recording state machine.
-  callbacks.loadSessions();
-
-  const currentStatus = callbacks.getRecordingStatus();
-  if (currentStatus !== 'processing') {
-    // A stale completion arrived while the user has already moved on (idle,
-    // recording, or paused). Suppress the workflow reset and the audio cue —
-    // playing it through speakers would bleed into the active mic capture.
-    return;
-  }
-
-  // Determine and set appropriate status
-  const resultStatus = determineRecordingStatus(session);
-  callbacks.setStatus(resultStatus);
-
-  // Update recording status to idle
-  callbacks.setRecordingStatus('idle');
-  callbacks.setIsProcessing(false);
-
-  // Fire-and-forget "ready" cue — advisory audio feedback that the transcript
-  // is now on the clipboard. Failures here are non-fatal by design (handled
-  // in the audio_cues Rust module).
-  callbacks.playReadyCue();
-
-  // Reset status after delay
-  setTimeout(() => callbacks.setStatus('Ready to record'), 5000);
-}
-
-/**
- * Handle transcription error event
- *
- * Mirrors `handleTranscriptionComplete`'s gating: an error event from a
- * background transcription must not clobber a recording the user has already
- * started afterward. See that function's docstring for details.
- */
-export function handleTranscriptionError(
-  sessionId: string,
-  error: string,
-  callbacks: {
-    setStatus: (status: string) => void;
-    setRecordingStatus: (status: RecordingStatus) => void;
-    setIsProcessing: (processing: boolean) => void;
-    loadSessions: () => Promise<void>;
-    getRecordingStatus: () => RecordingStatus;
-  }
-): void {
-  logger.error('Transcription failed for session:', sessionId, error);
-
-  // Always refresh the session list so the error state shows up even if we
-  // don't touch the recording workflow.
-  callbacks.loadSessions();
-
-  const currentStatus = callbacks.getRecordingStatus();
-  if (currentStatus !== 'processing') {
-    return;
-  }
-
-  callbacks.setStatus(`⚠️ Recording saved (transcription failed: ${error})`);
-  callbacks.setRecordingStatus('idle');
-  callbacks.setIsProcessing(false);
-
-  // Reset status after delay
-  setTimeout(() => callbacks.setStatus('Ready to record'), 5000);
-}
+const IDLE_DRIFT_POLL_MS = 3000;
 
 interface RecordingWorkflowState {
   sessions: Session[];
@@ -150,6 +48,12 @@ interface RecordingWorkflowState {
   recordingStatusRef: React.RefObject<RecordingStatus>;
   isProcessing: boolean;
   recordingDuration: number;
+  /**
+   * Seconds of audio the backend has durably committed to the in-flight
+   * WAV's on-disk header (i.e. survives a crash from this point on). `null`
+   * while no recording is active or the streaming writer has not yet flushed.
+   */
+  flushedThroughSeconds: number | null;
   status: string;
   selectedSession: Session | null;
 }
@@ -183,6 +87,7 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
   const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>('idle');
   const [isProcessing, setIsProcessing] = useState(false);
   const [recordingDuration, setRecordingDuration] = useState(0);
+  const [flushedThroughSeconds, setFlushedThroughSeconds] = useState<number | null>(null);
   const [status, setStatus] = useState("Ready to record");
 
   // Keep a live mirror of recordingStatus that long-lived listeners (e.g. the
@@ -358,11 +263,29 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
         }
       );
 
+      // Listen for capture-thread failures. The audio thread surfaces these
+      // when the stream dies mid-recording (e.g. mic disconnected) or fails
+      // to start. The handler resets workflow state and surfaces a visible
+      // warning so the failure is no longer silent.
+      const unlistenCaptureFailed = await listen<RecordingCaptureFailedPayload>(
+        RECORDING_CAPTURE_FAILED,
+        (event) =>
+          handleRecordingCaptureFailed(event.payload, {
+            setStatus,
+            setRecordingStatus,
+            setIsProcessing,
+            setRecordingDuration,
+            setSelectedId,
+            loadSessions,
+          })
+      );
+
       // Cleanup listeners on unmount
       return () => {
         unlistenComplete();
         unlistenError();
         unlistenCompressed();
+        unlistenCaptureFailed();
       };
     };
 
@@ -373,12 +296,32 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
     };
   }, [loadSessions]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Drift-callback bundle used by both reconciliation paths (the active-state
+  // tick and the idle-watcher) to apply backend truth to the workflow state.
+  // Defined once so both effects share an identity-stable shape.
+  const driftCallbacks: DriftCallbacks = {
+    setRecordingStatus,
+    setStatus,
+    setIsProcessing,
+    setRecordingDuration,
+    loadSessions,
+  };
+  const driftCallbacksRef = useRef<DriftCallbacks>(driftCallbacks);
+  useEffect(() => {
+    driftCallbacksRef.current = driftCallbacks;
+  });
+
   // Timer for recording duration. Display granularity is whole seconds
   // (MM:SS), so polling at 2 Hz keeps the timer visually current without
   // re-rendering the App tree 10x/sec — every tick rippled through React
   // reconciliation and forced a repaint of the timer span. Skip polling
   // entirely when the window is hidden: the timer is offscreen, and the
   // next interval tick after un-hide refreshes it within 500 ms.
+  //
+  // This tick also carries the active-state reconciliation: every duration
+  // poll fetches the backend's `recording_status` and corrects any drift.
+  // Backend is the source of truth, so a stale event or asynchronous signal
+  // that flipped the frontend out of sync self-heals here.
   useEffect(() => {
     let interval: number | undefined;
 
@@ -388,20 +331,79 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
     if (isTimingRecording && activity !== 'hidden') {
       interval = window.setInterval(async () => {
         try {
-          const duration = await recordingService.getRecordingDuration();
+          const [backendStatus, duration, flushed] = await Promise.all([
+            recordingService.getRecordingStatus(),
+            recordingService.getRecordingDuration(),
+            recordingService.getRecordingFlushedThroughSeconds(),
+          ]);
           setRecordingDuration(duration);
+          setFlushedThroughSeconds(flushed);
+          const action = detectStatusDrift(recordingStatusRef.current, backendStatus);
+          applyDriftAction(action, driftCallbacksRef.current);
         } catch (error) {
-          logger.error("Failed to get recording duration:", error);
+          logger.error("Failed to poll recording status/duration:", error);
         }
       }, 500);
     } else if (!isTimingRecording) {
       setRecordingDuration(0);
+      setFlushedThroughSeconds(null);
     }
 
     return () => {
       if (interval) clearInterval(interval);
     };
   }, [recordingStatus, recordingService, activity]);
+
+  // Idle-watcher: when the frontend believes it is `'idle'`, the fast active
+  // tick above is not running, so a backend that is still capturing would
+  // otherwise stay invisible to the UI. This is exactly the bug class the PRD
+  // calls out — "top bar reverted to Record while the recording was still
+  // going." Polling backend status every 3 s closes the window without
+  // burning the IPC bus.
+  //
+  // We also explicitly skip this when frontend status is `'processing'`: the
+  // transcription pipeline owns that state, and the backend briefly reports
+  // `'idle'` once transcription finishes on its own thread — we don't want to
+  // surface a false "recording ended unexpectedly" warning during that
+  // handoff.
+  useEffect(() => {
+    if (recordingStatus !== 'idle' || activity === 'hidden') {
+      return;
+    }
+
+    const interval = window.setInterval(async () => {
+      try {
+        const backendStatus = await recordingService.getRecordingStatus();
+        const action = detectStatusDrift(recordingStatusRef.current, backendStatus);
+        applyDriftAction(action, driftCallbacksRef.current);
+      } catch (error) {
+        logger.error("Failed to poll recording status for idle drift:", error);
+      }
+    }, IDLE_DRIFT_POLL_MS);
+
+    return () => clearInterval(interval);
+  }, [recordingStatus, recordingService, activity]);
+
+  // One-shot mount reconciliation: if a previous renderer/session left the
+  // backend mid-recording (e.g. window reload, dev-mode HMR, or process
+  // restart while the OS kept the audio thread alive), restore the UI to
+  // backend truth before the user notices the empty top bar.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const backendStatus = await recordingService.getRecordingStatus();
+        if (cancelled) return;
+        const action = detectStatusDrift(recordingStatusRef.current, backendStatus);
+        applyDriftAction(action, driftCallbacksRef.current);
+      } catch (error) {
+        logger.error("Failed initial recording-status reconciliation:", error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const selectedSession = findSessionById(sessions, selectedId);
 
@@ -412,6 +414,7 @@ export function useRecordingWorkflow(): RecordingWorkflowState & RecordingWorkfl
     recordingStatusRef,
     isProcessing,
     recordingDuration,
+    flushedThroughSeconds,
     status,
     selectedSession,
     handleStartRecording,

--- a/src/features/recording/RecordingControls.css
+++ b/src/features/recording/RecordingControls.css
@@ -6,12 +6,19 @@
   gap: var(--space-md);
 }
 
+.recording-timer-column {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-xs);
+  min-width: 100px;
+}
+
 .recording-timer {
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-semibold);
   color: var(--color-danger);
   font-family: var(--font-family-mono);
-  min-width: 100px;
   text-align: right;
   line-height: var(--line-height-normal);
   padding: var(--space-xs) var(--space-sm);
@@ -31,6 +38,24 @@
   margin-left: var(--space-sm);
   letter-spacing: 0.5px;
   opacity: 0.9;
+}
+
+.saved-through-indicator {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-tertiary);
+  font-family: var(--font-family-mono);
+  letter-spacing: 0.02em;
+  line-height: var(--line-height-tight);
+  padding: 2px var(--space-sm);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-base), background-color var(--transition-base);
+}
+
+.saved-through-indicator.falling {
+  color: var(--color-neutral-hover);
+  background-color: var(--color-neutral-bg);
+  font-weight: var(--font-weight-semibold);
 }
 
 .recording-buttons {

--- a/src/features/recording/RecordingControls.tsx
+++ b/src/features/recording/RecordingControls.tsx
@@ -2,6 +2,7 @@ import { formatDuration } from '../../shared/formatters/duration';
 import { RecordingStatus } from '../../api';
 import { Button, ProgressBar } from '../../shared/components';
 import { isPausedStatus, isIdleStatus } from './recordingStatusChecks';
+import { deriveSavedThroughIndicator } from './savedThroughIndicator';
 import AudioLevelIndicator from './AudioLevelIndicator';
 import { useAudioLevels } from './useAudioLevels';
 import { useTranscriptionProgress } from '../transcription/useTranscriptionProgress';
@@ -14,6 +15,13 @@ interface RecordingControlsProps {
   isProcessing: boolean;
   recordingDuration: number;
   audioDurationSeconds: number;
+  /**
+   * Seconds of audio durably committed to the in-flight WAV on disk. When
+   * non-null and > 0, surfaces a "Saved through MM:SS" trust signal below
+   * the timer. `null` while not recording or before the streaming writer's
+   * first flush.
+   */
+  flushedThroughSeconds: number | null;
   onStartRecording: () => void;
   onPauseRecording: () => void;
   onResumeRecording: () => void;
@@ -32,6 +40,7 @@ export default function RecordingControls({
   isProcessing,
   recordingDuration,
   audioDurationSeconds,
+  flushedThroughSeconds,
   onStartRecording,
   onPauseRecording,
   onResumeRecording,
@@ -41,6 +50,7 @@ export default function RecordingControls({
   const audioLevels = useAudioLevels(recordingStatus);
   const progress = useTranscriptionProgress(isProcessing, audioDurationSeconds);
   const displayData = prepareProgressDisplay(progress, formatHumanReadableDuration);
+  const savedThrough = deriveSavedThroughIndicator(flushedThroughSeconds, recordingDuration);
 
   if (isProcessing) {
     return (
@@ -86,9 +96,19 @@ export default function RecordingControls({
         <AudioLevelIndicator levels={audioLevels} />
       )}
 
-      <div className={`recording-timer ${isPaused ? 'paused' : ''}`}>
-        {formatDuration(recordingDuration)}
-        {isPaused && <span className="pause-indicator"> PAUSED</span>}
+      <div className="recording-timer-column">
+        <div className={`recording-timer ${isPaused ? 'paused' : ''}`}>
+          {formatDuration(recordingDuration)}
+          {isPaused && <span className="pause-indicator"> PAUSED</span>}
+        </div>
+        {savedThrough && (
+          <div
+            className={`saved-through-indicator ${savedThrough.isFalling ? 'falling' : ''}`}
+            title="The streaming WAV on disk reflects this much audio. If the app crashes, this much is recoverable."
+          >
+            {savedThrough.label}
+          </div>
+        )}
       </div>
 
       <div className="recording-buttons">

--- a/src/features/recording/partialRecoveryLabel.test.ts
+++ b/src/features/recording/partialRecoveryLabel.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { formatPartialDurationLabel } from './partialRecoveryLabel';
+
+describe('formatPartialDurationLabel', () => {
+  it('returns "before any audio" when duration rounds to zero', () => {
+    expect(formatPartialDurationLabel(0)).toBe('before any audio was captured');
+    expect(formatPartialDurationLabel(0.4)).toBe('before any audio was captured');
+  });
+
+  it('formats sub-minute durations as seconds only', () => {
+    expect(formatPartialDurationLabel(5)).toBe('~5s of audio');
+    expect(formatPartialDurationLabel(37.4)).toBe('~37s of audio');
+    // rounding up crosses the minute boundary
+    expect(formatPartialDurationLabel(59.6)).toBe('~1m 00s of audio');
+  });
+
+  it('formats minute-plus durations as MM SS', () => {
+    expect(formatPartialDurationLabel(60)).toBe('~1m 00s of audio');
+    expect(formatPartialDurationLabel(75)).toBe('~1m 15s of audio');
+    expect(formatPartialDurationLabel(605)).toBe('~10m 05s of audio');
+  });
+
+  it('clamps negative inputs to zero', () => {
+    expect(formatPartialDurationLabel(-1)).toBe('before any audio was captured');
+  });
+});

--- a/src/features/recording/partialRecoveryLabel.ts
+++ b/src/features/recording/partialRecoveryLabel.ts
@@ -1,0 +1,25 @@
+/**
+ * Format the duration component of the capture-failure status message.
+ *
+ * The failure path needs a different vocabulary than the live "Saved through"
+ * trust signal: this one renders past-tense, rounded duration in plain
+ * English ("~37s of audio") rather than the precise MM:SS the timer displays.
+ * Co-located with the recording feature so the workflow hook stays focused
+ * on orchestration.
+ *
+ * Returns whole seconds (rounded). When the rounded value is 0 it falls back
+ * to a human-readable sentence so the failure message reads naturally even
+ * when capture died before any audio arrived.
+ */
+export function formatPartialDurationLabel(partialDurationSeconds: number): string {
+  const rounded = Math.max(0, Math.round(partialDurationSeconds));
+  if (rounded === 0) {
+    return "before any audio was captured";
+  }
+  const minutes = Math.floor(rounded / 60);
+  const seconds = rounded % 60;
+  if (minutes === 0) {
+    return `~${seconds}s of audio`;
+  }
+  return `~${minutes}m ${seconds.toString().padStart(2, '0')}s of audio`;
+}

--- a/src/features/recording/recordingStatusDrift.test.ts
+++ b/src/features/recording/recordingStatusDrift.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  detectStatusDrift,
+  applyDriftAction,
+  DriftCallbacks,
+} from './recordingStatusDrift';
+import { RecordingStatus } from '../../api';
+
+describe('detectStatusDrift', () => {
+  describe('when frontend and backend agree', () => {
+    const statuses: RecordingStatus[] = ['idle', 'recording', 'paused', 'processing'];
+    statuses.forEach((status) => {
+      it(`returns 'none' when both are ${status}`, () => {
+        expect(detectStatusDrift(status, status)).toEqual({ kind: 'none' });
+      });
+    });
+  });
+
+  describe("when frontend is 'processing'", () => {
+    it.each<RecordingStatus>(['idle', 'recording', 'paused'])(
+      "returns 'none' even if backend is %s (transcription pipeline owns the state)",
+      (backendStatus) => {
+        expect(detectStatusDrift('processing', backendStatus)).toEqual({ kind: 'none' });
+      }
+    );
+  });
+
+  describe('restore-from-backend (the reported "top bar reverted" bug)', () => {
+    it("restores when frontend idle but backend is recording", () => {
+      expect(detectStatusDrift('idle', 'recording')).toEqual({
+        kind: 'restore-from-backend',
+        backendStatus: 'recording',
+      });
+    });
+
+    it("restores when frontend idle but backend is paused", () => {
+      expect(detectStatusDrift('idle', 'paused')).toEqual({
+        kind: 'restore-from-backend',
+        backendStatus: 'paused',
+      });
+    });
+
+    it('mirrors backend silently when frontend says recording but backend says paused', () => {
+      expect(detectStatusDrift('recording', 'paused')).toEqual({
+        kind: 'restore-from-backend',
+        backendStatus: 'paused',
+      });
+    });
+
+    it('mirrors backend silently when frontend says paused but backend says recording', () => {
+      expect(detectStatusDrift('paused', 'recording')).toEqual({
+        kind: 'restore-from-backend',
+        backendStatus: 'recording',
+      });
+    });
+  });
+
+  describe('announce-unexpected-end', () => {
+    it('announces when frontend thinks recording but backend has gone idle', () => {
+      expect(detectStatusDrift('recording', 'idle')).toEqual({
+        kind: 'announce-unexpected-end',
+      });
+    });
+
+    it('announces when frontend thinks paused but backend has gone idle', () => {
+      expect(detectStatusDrift('paused', 'idle')).toEqual({
+        kind: 'announce-unexpected-end',
+      });
+    });
+  });
+
+  describe('backend in processing while frontend is something else', () => {
+    it("returns 'none' when frontend idle and backend processing", () => {
+      // backend is finishing a stop the UI hasn't observed yet — let the
+      // transcription event listeners drive the UI back to idle.
+      expect(detectStatusDrift('idle', 'processing')).toEqual({ kind: 'none' });
+    });
+
+    it("returns 'none' when frontend recording and backend processing", () => {
+      expect(detectStatusDrift('recording', 'processing')).toEqual({ kind: 'none' });
+    });
+
+    it("returns 'none' when frontend paused and backend processing", () => {
+      expect(detectStatusDrift('paused', 'processing')).toEqual({ kind: 'none' });
+    });
+  });
+});
+
+describe('applyDriftAction', () => {
+  function makeCallbacks(): DriftCallbacks & {
+    _calls: {
+      setRecordingStatus: ReturnType<typeof vi.fn>;
+      setStatus: ReturnType<typeof vi.fn>;
+      setIsProcessing: ReturnType<typeof vi.fn>;
+      setRecordingDuration: ReturnType<typeof vi.fn>;
+      loadSessions: ReturnType<typeof vi.fn>;
+    };
+  } {
+    const calls = {
+      setRecordingStatus: vi.fn(),
+      setStatus: vi.fn(),
+      setIsProcessing: vi.fn(),
+      setRecordingDuration: vi.fn(),
+      loadSessions: vi.fn().mockResolvedValue(undefined),
+    };
+    return {
+      _calls: calls,
+      setRecordingStatus: calls.setRecordingStatus,
+      setStatus: calls.setStatus,
+      setIsProcessing: calls.setIsProcessing,
+      setRecordingDuration: calls.setRecordingDuration,
+      loadSessions: calls.loadSessions,
+    };
+  }
+
+  it("'none' triggers zero side effects", () => {
+    const cb = makeCallbacks();
+    applyDriftAction({ kind: 'none' }, cb);
+    expect(cb._calls.setRecordingStatus).not.toHaveBeenCalled();
+    expect(cb._calls.setStatus).not.toHaveBeenCalled();
+    expect(cb._calls.setIsProcessing).not.toHaveBeenCalled();
+    expect(cb._calls.setRecordingDuration).not.toHaveBeenCalled();
+    expect(cb._calls.loadSessions).not.toHaveBeenCalled();
+  });
+
+  it("'restore-from-backend' (recording) sets recording status + recording message", () => {
+    const cb = makeCallbacks();
+    applyDriftAction({ kind: 'restore-from-backend', backendStatus: 'recording' }, cb);
+    expect(cb._calls.setRecordingStatus).toHaveBeenCalledWith('recording');
+    expect(cb._calls.setStatus).toHaveBeenCalledWith('⏺️ Recording...');
+    expect(cb._calls.setIsProcessing).not.toHaveBeenCalled();
+    expect(cb._calls.loadSessions).not.toHaveBeenCalled();
+  });
+
+  it("'restore-from-backend' (paused) sets paused status + paused message", () => {
+    const cb = makeCallbacks();
+    applyDriftAction({ kind: 'restore-from-backend', backendStatus: 'paused' }, cb);
+    expect(cb._calls.setRecordingStatus).toHaveBeenCalledWith('paused');
+    expect(cb._calls.setStatus).toHaveBeenCalledWith('⏸️ Recording paused');
+  });
+
+  it("'announce-unexpected-end' wipes recording UI and refreshes sessions", () => {
+    const cb = makeCallbacks();
+    applyDriftAction({ kind: 'announce-unexpected-end' }, cb);
+    expect(cb._calls.setRecordingStatus).toHaveBeenCalledWith('idle');
+    expect(cb._calls.setIsProcessing).toHaveBeenCalledWith(false);
+    expect(cb._calls.setRecordingDuration).toHaveBeenCalledWith(0);
+    expect(cb._calls.setStatus).toHaveBeenCalledWith('⚠️ Recording ended unexpectedly');
+    expect(cb._calls.loadSessions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/recording/recordingStatusDrift.ts
+++ b/src/features/recording/recordingStatusDrift.ts
@@ -1,0 +1,119 @@
+import { RecordingStatus } from "../../api";
+
+/**
+ * Corrective action the workflow should take when the frontend's optimistic
+ * `recordingStatus` disagrees with the backend's authoritative state.
+ *
+ * Backend wins — the frontend mirrors the backend, never the other way around.
+ * See `docs/PRD-recording-loss-prevention.md` for the motivation: stale events,
+ * timer fires, or any other async signal that wipes the recording UI must
+ * self-heal on the next reconciliation tick.
+ */
+export type DriftAction =
+  | { kind: 'none' }
+  | { kind: 'restore-from-backend'; backendStatus: 'recording' | 'paused' }
+  | { kind: 'announce-unexpected-end' };
+
+/**
+ * Pure drift-detection: given the frontend's current `recordingStatus` and the
+ * backend's authoritative status, return the corrective action the workflow
+ * should apply.
+ *
+ * Reconciliation policy:
+ *
+ *   - frontend `idle` + backend `recording`/`paused` → **restore from backend**
+ *     (the reported "top bar reverted to Record" symptom — something async
+ *     dropped the UI to idle while capture is still running)
+ *
+ *   - frontend `recording`/`paused` + backend `idle` → **announce unexpected end**
+ *     (the backend's recording ended out from under us — likely a capture-thread
+ *     failure or an external stop. Surface it explicitly rather than silently
+ *     pretending capture is still active.)
+ *
+ *   - frontend `recording` ↔ backend `paused` (or vice versa) → **mirror backend**
+ *     (small disagreement, no warning — the UI just realigns)
+ *
+ *   - frontend `processing` → **no-op**
+ *     (the transcription event listeners own this state; the backend may
+ *     briefly report `idle` after async transcription completes, and we don't
+ *     want to surface a false "recording ended" warning during that handoff.)
+ *
+ *   - all other combinations (notably both `idle` and frontend≡backend) →
+ *     **no-op**
+ */
+export function detectStatusDrift(
+  frontendStatus: RecordingStatus,
+  backendStatus: RecordingStatus
+): DriftAction {
+  if (frontendStatus === 'processing') {
+    return { kind: 'none' };
+  }
+
+  if (frontendStatus === backendStatus) {
+    return { kind: 'none' };
+  }
+
+  const frontendIsActive = frontendStatus === 'recording' || frontendStatus === 'paused';
+  const backendIsActive = backendStatus === 'recording' || backendStatus === 'paused';
+
+  if (!frontendIsActive && backendIsActive) {
+    return { kind: 'restore-from-backend', backendStatus: backendStatus as 'recording' | 'paused' };
+  }
+
+  if (frontendIsActive && backendStatus === 'idle') {
+    return { kind: 'announce-unexpected-end' };
+  }
+
+  // Both active but differ (recording vs paused) — silently mirror.
+  if (frontendIsActive && backendIsActive) {
+    return { kind: 'restore-from-backend', backendStatus: backendStatus as 'recording' | 'paused' };
+  }
+
+  // Backend in `processing` while frontend is anything but `processing`: the
+  // backend is finishing a stop the UI hasn't caught up to yet. The
+  // `transcription-complete`/`-error` listeners will land us back at `idle`
+  // when transcription finishes; no reconciliation needed here.
+  return { kind: 'none' };
+}
+
+/**
+ * Callback bundle used by `applyDriftAction` to reflect a drift correction in
+ * the workflow hook's state. The shape mirrors the existing
+ * `handleTranscriptionComplete` callbacks bag in `useRecordingWorkflow` so
+ * both helpers compose with the same setters.
+ */
+export interface DriftCallbacks {
+  setRecordingStatus: (status: RecordingStatus) => void;
+  setStatus: (message: string) => void;
+  setIsProcessing: (processing: boolean) => void;
+  setRecordingDuration: (duration: number) => void;
+  loadSessions: () => Promise<void>;
+}
+
+/**
+ * Apply a `DriftAction` to the workflow's state via injected setters.
+ *
+ * Kept side-effect-free for the `none` arm so reconciliation ticks that find
+ * no drift cause zero React re-renders.
+ */
+export function applyDriftAction(action: DriftAction, callbacks: DriftCallbacks): void {
+  switch (action.kind) {
+    case 'none':
+      return;
+    case 'restore-from-backend':
+      callbacks.setRecordingStatus(action.backendStatus);
+      callbacks.setStatus(
+        action.backendStatus === 'paused'
+          ? '⏸️ Recording paused'
+          : '⏺️ Recording...'
+      );
+      return;
+    case 'announce-unexpected-end':
+      callbacks.setRecordingStatus('idle');
+      callbacks.setIsProcessing(false);
+      callbacks.setRecordingDuration(0);
+      callbacks.setStatus('⚠️ Recording ended unexpectedly');
+      void callbacks.loadSessions();
+      return;
+  }
+}

--- a/src/features/recording/savedThroughIndicator.test.ts
+++ b/src/features/recording/savedThroughIndicator.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSavedThroughIndicator } from './savedThroughIndicator';
+
+describe('deriveSavedThroughIndicator', () => {
+  it('returns null when no flush has been reported yet', () => {
+    expect(deriveSavedThroughIndicator(null, 0)).toBeNull();
+    expect(deriveSavedThroughIndicator(null, 30)).toBeNull();
+  });
+
+  it('returns null when nothing has been flushed yet (0s)', () => {
+    expect(deriveSavedThroughIndicator(0, 1)).toBeNull();
+  });
+
+  it('formats a healthy flush state as "Saved through MM:SS"', () => {
+    const result = deriveSavedThroughIndicator(123, 124);
+    expect(result).toEqual({ label: 'Saved through 2:03', isFalling: false });
+  });
+
+  it('marks the indicator as falling when the writer is more than 5s behind', () => {
+    const result = deriveSavedThroughIndicator(60, 90);
+    expect(result?.isFalling).toBe(true);
+  });
+
+  it('does not mark falling for a tiny lag', () => {
+    const result = deriveSavedThroughIndicator(60, 62);
+    expect(result?.isFalling).toBe(false);
+  });
+
+  it('handles flushed > duration (clock-skew safety) without panicking', () => {
+    const result = deriveSavedThroughIndicator(70, 60);
+    expect(result?.isFalling).toBe(false);
+  });
+});

--- a/src/features/recording/savedThroughIndicator.ts
+++ b/src/features/recording/savedThroughIndicator.ts
@@ -1,0 +1,41 @@
+import { formatDuration } from '../../shared/formatters/duration';
+
+/**
+ * Pre-rendered label for the "Saved through MM:SS" trust signal shown below
+ * the recording timer.
+ *
+ * Returns `null` when the indicator should be hidden — either because the
+ * backend has not yet reported a value or because no audio has been durably
+ * committed to disk. The component reads `display !== null` and renders nothing
+ * in that case rather than dropping in an empty row.
+ *
+ * Co-located with the rest of the recording feature so the `.tsx` file stays
+ * pure presentation per CLAUDE.md.
+ */
+export interface SavedThroughIndicatorDisplay {
+  label: string;
+  /** True when streaming has clearly fallen behind the timer by more than a
+   *  few seconds — useful if the indicator wants to dim itself or surface a
+   *  hint, but currently rendered identically to the healthy state. */
+  isFalling: boolean;
+}
+
+const FALLING_BEHIND_SECONDS = 5;
+
+export function deriveSavedThroughIndicator(
+  flushedThroughSeconds: number | null,
+  recordingDurationSeconds: number
+): SavedThroughIndicatorDisplay | null {
+  if (flushedThroughSeconds === null) {
+    return null;
+  }
+  if (flushedThroughSeconds <= 0) {
+    return null;
+  }
+  const label = `Saved through ${formatDuration(flushedThroughSeconds)}`;
+  const lag = Math.max(0, recordingDurationSeconds - flushedThroughSeconds);
+  return {
+    label,
+    isFalling: lag > FALLING_BEHIND_SECONDS,
+  };
+}

--- a/src/features/recording/workflowEventHandlers.ts
+++ b/src/features/recording/workflowEventHandlers.ts
@@ -1,0 +1,179 @@
+import {
+  Session,
+  RecordingStatus,
+  RecordingCaptureFailedPayload,
+} from '../../api';
+import { logger } from '../../shared/utils/logger';
+import { formatPartialDurationLabel } from './partialRecoveryLabel';
+
+/**
+ * Pure session/workflow helpers extracted from `useRecordingWorkflow` so the
+ * hook file stays focused on React orchestration and so each helper can be
+ * tested without mounting the hook.
+ */
+
+/**
+ * Determines appropriate status message based on recording result.
+ */
+export function determineRecordingStatus(session: Session): string {
+  if (session.transcript_path && session.transcript_path.length > 0) {
+    if (session.clipboard_copied) {
+      return "✅ Transcript copied to clipboard!";
+    }
+    return "⚠️ Transcription complete (clipboard copy failed - use Copy button)";
+  }
+  return "⚠️ Recording saved (transcription failed - check Whisper setup)";
+}
+
+/**
+ * Finds session by ID or returns null.
+ */
+export function findSessionById(sessions: Session[], id: string | null): Session | null {
+  if (!id) return null;
+  return sessions.find(s => s.id === id) || null;
+}
+
+/**
+ * Selects the first session if none selected and sessions are available.
+ */
+export function autoSelectFirstSession(
+  sessions: Session[],
+  currentSelectedId: string | null
+): string | null {
+  if (sessions.length > 0 && !currentSelectedId) {
+    return sessions[0].id;
+  }
+  return currentSelectedId;
+}
+
+/**
+ * Handle transcription completion event.
+ *
+ * Background transcriptions (a prior recording or a user-triggered retranscribe)
+ * can finish while the user is already in the middle of a *new* recording —
+ * including paused. Without `getRecordingStatus`, this handler would
+ * unconditionally flip `recordingStatus` to `'idle'` and wipe the in-progress
+ * recording out of the UI even though the backend is still capturing it. We
+ * gate the workflow-state mutations on actually being in `'processing'`; if
+ * we're not, the event corresponds to background work and we only refresh
+ * the session list (so the completed transcript appears in the sidebar).
+ */
+export function handleTranscriptionComplete(
+  session: Session,
+  callbacks: {
+    setStatus: (status: string) => void;
+    setRecordingStatus: (status: RecordingStatus) => void;
+    setIsProcessing: (processing: boolean) => void;
+    loadSessions: () => Promise<void>;
+    playReadyCue: () => void;
+    getRecordingStatus: () => RecordingStatus;
+  }
+): void {
+  logger.info('Transcription completed:', session.id);
+
+  // Always refresh the session list so the completed transcript shows up,
+  // even if we shouldn't touch the recording state machine.
+  callbacks.loadSessions();
+
+  const currentStatus = callbacks.getRecordingStatus();
+  if (currentStatus !== 'processing') {
+    // A stale completion arrived while the user has already moved on (idle,
+    // recording, or paused). Suppress the workflow reset and the audio cue —
+    // playing it through speakers would bleed into the active mic capture.
+    return;
+  }
+
+  const resultStatus = determineRecordingStatus(session);
+  callbacks.setStatus(resultStatus);
+
+  callbacks.setRecordingStatus('idle');
+  callbacks.setIsProcessing(false);
+
+  // Fire-and-forget "ready" cue — advisory audio feedback that the transcript
+  // is now on the clipboard. Failures here are non-fatal by design (handled
+  // in the audio_cues Rust module).
+  callbacks.playReadyCue();
+
+  // Reset status after delay
+  setTimeout(() => callbacks.setStatus('Ready to record'), 5000);
+}
+
+/**
+ * Handle a `recording-capture-failed` event from the audio capture thread.
+ *
+ * Composes the user-facing message and resets the workflow to idle. Backend
+ * has already reset its own status to idle before emitting (see
+ * `capture_failure.rs::propagate_capture_failure`), so the reconciliation
+ * tick won't fight us here.
+ *
+ * Always refreshes the session list — when `recovered_session` is non-null,
+ * the partial recording is already on disk and the user should see it appear
+ * in the sidebar immediately.
+ */
+export function handleRecordingCaptureFailed(
+  payload: RecordingCaptureFailedPayload,
+  callbacks: {
+    setStatus: (status: string) => void;
+    setRecordingStatus: (status: RecordingStatus) => void;
+    setIsProcessing: (processing: boolean) => void;
+    setRecordingDuration: (duration: number) => void;
+    setSelectedId: (id: string | null) => void;
+    loadSessions: () => Promise<void>;
+  }
+): void {
+  logger.error('Recording capture failed:', payload.reason);
+
+  const durationLabel = formatPartialDurationLabel(payload.partial_duration_seconds);
+  const message = payload.recovered_session
+    ? `⚠️ Recording stopped unexpectedly. Saved ${durationLabel} — ${payload.reason}`
+    : `⚠️ Recording stopped unexpectedly (no audio recovered) — ${payload.reason}`;
+
+  callbacks.setStatus(message);
+  callbacks.setRecordingStatus('idle');
+  callbacks.setIsProcessing(false);
+  callbacks.setRecordingDuration(0);
+
+  // Always refresh — when the partial save succeeded, the new session needs
+  // to appear in the sidebar immediately so the user can open + retranscribe.
+  void callbacks.loadSessions();
+
+  // Surface the recovered session in the viewer so the user lands on it
+  // directly when they come back to the window.
+  if (payload.recovered_session) {
+    callbacks.setSelectedId(payload.recovered_session.id);
+  }
+}
+
+/**
+ * Handle transcription error event.
+ *
+ * Mirrors `handleTranscriptionComplete`'s gating: an error event from a
+ * background transcription must not clobber a recording the user has already
+ * started afterward. See that function's docstring for details.
+ */
+export function handleTranscriptionError(
+  sessionId: string,
+  error: string,
+  callbacks: {
+    setStatus: (status: string) => void;
+    setRecordingStatus: (status: RecordingStatus) => void;
+    setIsProcessing: (processing: boolean) => void;
+    loadSessions: () => Promise<void>;
+    getRecordingStatus: () => RecordingStatus;
+  }
+): void {
+  logger.error('Transcription failed for session:', sessionId, error);
+
+  callbacks.loadSessions();
+
+  const currentStatus = callbacks.getRecordingStatus();
+  if (currentStatus !== 'processing') {
+    return;
+  }
+
+  callbacks.setStatus(`⚠️ Recording saved (transcription failed: ${error})`);
+  callbacks.setRecordingStatus('idle');
+  callbacks.setIsProcessing(false);
+
+  setTimeout(() => callbacks.setStatus('Ready to record'), 5000);
+}

--- a/src/features/sessions/SessionViewer.tsx
+++ b/src/features/sessions/SessionViewer.tsx
@@ -8,6 +8,27 @@ import { useTranscriptViewer } from './useTranscriptViewer';
 import './SessionViewer.css';
 
 /**
+ * Pick the duration to feed into the transcribing progress UI.
+ *
+ * During processing, the existing transcription-estimate widget keys off the
+ * full audio duration of the just-stopped session (so it can extrapolate "how
+ * much of the recording have we transcribed so far"). While recording, the
+ * live timer is the right input. This was previously an inline ternary at the
+ * `RecordingControls` call site — extracted so the `.tsx` stays presentation-
+ * only per the React separation doctrine.
+ */
+function deriveAudioDurationForControls(
+  isProcessing: boolean,
+  selectedSession: Session | null,
+  recordingDuration: number,
+): number {
+  if (isProcessing && selectedSession) {
+    return selectedSession.duration;
+  }
+  return recordingDuration;
+}
+
+/**
  * Determines the CSS class for status messages based on content
  */
 function getStatusClass(status: string): string {
@@ -37,6 +58,7 @@ interface SessionViewerProps {
   recordingStatus: RecordingStatus;
   isProcessing: boolean;
   recordingDuration: number;
+  flushedThroughSeconds: number | null;
   status: string;
   onStartRecording: () => void;
   onPauseRecording: () => void;
@@ -52,6 +74,7 @@ export default function SessionViewer({
   recordingStatus,
   isProcessing,
   recordingDuration,
+  flushedThroughSeconds,
   status,
   onStartRecording,
   onPauseRecording,
@@ -84,11 +107,12 @@ export default function SessionViewer({
           recordingStatus={recordingStatus}
           isProcessing={isProcessing}
           recordingDuration={recordingDuration}
-          audioDurationSeconds={
-            isProcessing && selectedSession
-              ? selectedSession.duration
-              : recordingDuration
-          }
+          flushedThroughSeconds={flushedThroughSeconds}
+          audioDurationSeconds={deriveAudioDurationForControls(
+            isProcessing,
+            selectedSession,
+            recordingDuration,
+          )}
           onStartRecording={onStartRecording}
           onPauseRecording={onPauseRecording}
           onResumeRecording={onResumeRecording}


### PR DESCRIPTION
## Summary
The user has lost long voice recordings several times to a recurring symptom: the top-bar UI silently reverting from "Recording…" to "Click to record" with the audio gone. This PR makes recordings durable by default — every long capture streams to a WAV file on disk continuously, so a crash, an HMR reload, or even an accidental cancel no longer destroys the audio. The most recent loss traced to the OS-wide Escape shortcut firing while the window was unfocused; cancel is now both focus-gated AND non-destructive (moves the WAV to a quarantine folder instead of unlinking).

## Technical Details
- **Reconciliation tick.** The 500 ms duration poll now also calls `getRecordingStatus()` and applies a pure `detectStatusDrift()` action; a 3 s idle-watcher and a mount-time one-shot catch the cases where the active tick is paused.
- **Streaming WAV writer.** New `StreamingWavWriter` writes `audio/.in-flight/<id>.wav` with periodic header re-flush; `repair_partial_wav_header` reconstructs sizes from file length when the previous run crashed before finalize. `stop_recording` promotes the in-flight file by rename instead of re-encoding from RAM.
- **Visible capture failure.** CPAL `err_fn` now populates `state.capture.capture_error` (was `eprintln!`-only); the capture loop drains it and emits `recording-capture-failed` with the partial-save session attached.
- **Startup crash recovery.** New `recovery.rs` scans `audio/.in-flight/` at app boot and surfaces orphans as `♻️ Recovered from previous session` rows.
- **Cancel hardening.** `cancel_recording` now moves the in-flight WAV to `audio/.cancelled/<timestamp>_<id>.wav` instead of `remove_file`. The global cancel shortcut handler in `shortcuts/registrar.rs` calls `thoughtcast_window_is_focused()` before emitting, so Escape elsewhere on the OS is logged and swallowed.
- **Persistent file logging.** `tauri-plugin-log` now writes to `~/Documents/ThoughtCast/logs/thoughtcast.log` in both dev and release with 5 MB rotation; every Tauri command logs, with `cancel_recording` at `warn` level for forensics.
- **Architecture hardening.** Split a 974-line `lifecycle.rs` into `lifecycle.rs` / `transcription_orchestration.rs` / `retranscription.rs`. Introduced `CaptureChannel` sub-struct grouping the four capture-thread-published fields. Added `Session::new_for_processing` / `Session::new_unrecovered` constructors + preview consts to eliminate four-way row-construction duplication. Extracted pure helpers from the workflow hook into `workflowEventHandlers.ts`, `recordingStatusDrift.ts`, `savedThroughIndicator.ts`, `partialRecoveryLabel.ts`.
- **UI trust signal.** New `get_recording_flushed_through_seconds` Tauri command drives a "Saved through MM:SS" indicator below the recording timer.